### PR TITLE
Added options to checklib.py to help with automation of checks

### DIFF
--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import json
 from schlib import *
 from print_color import *
 from rules import *
@@ -12,10 +13,24 @@ parser.add_argument('-c', '--component', help='check only a specific component (
 parser.add_argument('--fix', help='fix the violations if possible', action='store_true')
 parser.add_argument('--nocolor', help='does not use colors to show the output', action='store_true')
 parser.add_argument('--enable-extra', help='enable extra checking', action='store_true')
+parser.add_argument('--ignore-errors', help='json file with all errors to be ignored')
+parser.add_argument('--json-errors', help='create json file with all errors with supplied argument as filename')
+parser.add_argument('--silent', help='only print when a component has violations', action='store_true')
 parser.add_argument('-v', '--verbose', help='show status of all components and extra information about the violation', action='count')
 args = parser.parse_args()
 
 printer = PrintColor(use_color = not args.nocolor)
+
+if args.ignore_errors:
+    with open(args.ignore_errors) as ignore_file:
+        ignored_errors = json.load(ignore_file)
+else:
+    ignored_errors = {}
+
+# dict set up as:
+# library is the key and the value is a dict of components with errors
+# each component dict has the component as the key and a list of errors as the value
+errors = {}
 
 # force to be verbose if is looking for a specific component
 if not args.verbose and args.component: args.verbose = 1
@@ -34,22 +49,37 @@ for f in dir():
 
 for libfile in args.libfiles:
     lib = SchLib(libfile)
+    # create dict to store components and their errors for this library
+    errors[libfile] = {}
     n_components = 0
-    printer.purple('library: %s' % libfile)
+    if not args.silent:
+        printer.purple('library: %s' % libfile)
     for component in lib.components:
         # skip components with non matching names
         if args.component and args.component != component.name: continue
         n_components += 1
 
-        printer.green('checking component: %s' % component.name)
+        if not args.silent:
+            printer.green('checking component: %s' % component.name)
+
+        # create list to store errors for this component
+        errors[libfile][component.name] = []
 
         # check the rules
         n_violations = 0
         for rule in all_rules:
             rule = rule(component)
+            if ignored_errors:
+                if libfile in ignored_errors:
+                    if component.name in ignored_errors[libfile]:
+                        if rule.name in ignored_errors[libfile][component.name]:
+                            # skip this rule check
+                            continue
             if rule.check():
                 n_violations += 1
-                printer.yellow('Violating ' +  rule.name, indentation=2)
+                if not args.silent:
+                    printer.yellow('Violating ' +  rule.name, indentation=2)
+                errors[libfile][component.name].append(rule.name)
                 if args.verbose:
                     printer.light_blue(rule.description, indentation=4, max_width=100)
 
@@ -78,9 +108,17 @@ for libfile in args.libfiles:
         if args.enable_extra:
             for ec in all_ec:
                 ec = ec(component)
+                if ignored_errors:
+                    if libfile in ignored_errors:
+                        if component.name in ignored_errors[libfile]:
+                            if ec.name in ignored_errors[libfile][component.name]:
+                                # skip this rule check
+                                continue
                 if ec.check():
                     n_violations += 1
-                    printer.yellow('Violating ' +  ec.name, indentation=2)
+                    errors[libfile][component.name].append(ec.name)
+                    if not args.silent:
+                        printer.yellow('Violating ' +  ec.name, indentation=2)
 
                     if args.verbose:
                         printer.light_blue(ec.description, indentation=4, max_width=100)
@@ -100,7 +138,18 @@ for libfile in args.libfiles:
 
         # check the number of violations
         if n_violations == 0:
-            printer.light_green('No violations found', indentation=2)
+            if not args.silent:
+                printer.light_green('No violations found', indentation=2)
+        else:
+            printer.green('checking component: %s' % component.name)
+            for i in errors[libfile][component.name]:
+                printer.yellow('Violating ' +  i, indentation=2)
 
     if args.fix:
         lib.save()
+
+if args.json_errors:
+    # open new json file for writing errors in json format
+    errors_file = open(args.json_errors, 'w')
+    json.dump(errors, errors_file)
+    errors_file.close()


### PR DESCRIPTION
Hi,

I made these changes a while back for the github pull request checker.

The three changes are:
1) a flag to not print out violations (the PR checker doesn't need all 1000 violations that the library has to be printed out)
2) a flag to store all errors in a json format. This is so all of the violations the library has can be removed when checking the pull request.
3) Lastly a flag to read in the previous errors in json and ignore those errors.