### PR TITLE
Improve verbose output

### DIFF
--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -55,19 +55,20 @@ for libfile in args.libfiles:
 
                 if args.fix:
                     rule.fix()
-            if args.verbose:
-                for msg in rule.messageBuffer:
-                    if msg[1] <= args.verbose:
-                        if msg[2]==0:#Serverity.INFO
-                            printer.gray(msg[0], indentation=4)
-                        elif msg[2]==1:#Serverity.WARNING
-                            printer.brown(msg[0], indentation=4)
-                        elif msg[2]==2:#Serverity.ERROR
-                            printer.red(msg[0], indentation=4)
-                        elif msg[2]==3:#Serverity.SUCCESS
-                            printer.green(msg[0], indentation=4)
-                        else:
-                            printer.red("unknown severity: "+msg[2])
+
+                if args.verbose:
+                    for msg in rule.messageBuffer:
+                        if msg[1] <= args.verbose:
+                            if msg[2]==0:#Serverity.INFO
+                                printer.gray(msg[0], indentation=4)
+                            elif msg[2]==1:#Serverity.WARNING
+                                printer.brown(msg[0], indentation=4)
+                            elif msg[2]==2:#Serverity.ERROR
+                                printer.red(msg[0], indentation=4)
+                            elif msg[2]==3:#Serverity.SUCCESS
+                                printer.green(msg[0], indentation=4)
+                            else:
+                                printer.red("unknown severity: "+msg[2])
 
         # extra checking
         if args.enable_extra:

--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -53,26 +53,21 @@ for libfile in args.libfiles:
                 if args.verbose:
                     printer.light_blue(rule.description, indentation=4, max_width=100)
 
-                    # example of customized printing feedback by checking the rule name
-                    # and a specific variable of the rule
-                    # note that the following text will only be printed when verbosity level is greater than 1
-                    if rule.name == 'Rule 3.1' and args.verbose > 1:
-                        for pin in rule.violating_pins:
-                            printer.red('pin: %s (%s), posx %s, posy %s' %
-                                       (pin['name'], pin['num'], pin['posx'], pin['posy']), indentation=4)
-
-                    if rule.name == 'Rule 3.2' and args.verbose > 1:
-                        for pin in rule.violating_pins:
-                            printer.red('pin: %s (%s), length %s' %
-                                       (pin['name'], pin['num'], pin['length']), indentation=4)
-
-                    if rule.name == 'Rule 3.8' and args.verbose:
-                        if rule.only_datasheet_missing:
-                            printer.brown("[warn] Please provide a datasheet link if it isn't a generic component",
-                                          indentation=4)
-
-            if args.fix:
-                rule.fix()
+                if args.fix:
+                    rule.fix()
+            if args.verbose:
+                for msg in rule.messageBuffer:
+                    if msg[1] <= args.verbose:
+                        if msg[2]==0:#Serverity.INFO
+                            printer.gray(msg[0], indentation=4)
+                        elif msg[2]==1:#Serverity.WARNING
+                            printer.brown(msg[0], indentation=4)
+                        elif msg[2]==2:#Serverity.ERROR
+                            printer.red(msg[0], indentation=4)
+                        elif msg[2]==3:#Serverity.SUCCESS
+                            printer.green(msg[0], indentation=4)
+                        else:
+                            printer.red("unknown severity: "+msg[2])
 
         # extra checking
         if args.enable_extra:

--- a/schlib/rules/EC01.py
+++ b/schlib/rules/EC01.py
@@ -16,26 +16,35 @@ class Rule(KLCRule):
         Proceeds the checking of the rule.
         The following variables will be accessible after checking:
             * probably_wrong_pin_types
+            * double_inverted_pins
         """
         self.probably_wrong_pin_types = []
+        self.double_inverted_pins = []
         for pin in self.component.pins:
             if ('GND' in pin['name'].upper() or
                 'VCC' in pin['name'].upper() or
                 'VDD' in pin['name'].upper()):
                 if pin['electrical_type'] != 'W':
                     self.probably_wrong_pin_types.append(pin)
+                    self.verboseOut(Verbosity.HIGH,Severity.WARNING,'pin {0} ({1}): {2} ({3}), expected: W ({4})'.format(pin['name'], pin['num'], pin['electrical_type'],pinElecticalTypeToStr(pin['electrical_type']),pinElecticalTypeToStr("W")))
 
             # check if name contains overlining
-            m = re.search('(\~)(.*)(\~)', pin['name'])
+            m = re.search('(\~)(.+)', pin['name'])
             if m and pin['pin_type'] == 'I':
-                self.probably_wrong_pin_types.append(pin)
+                self.double_inverted_pins.append(pin)
+                self.verboseOut(Verbosity.HIGH,Severity.WARNING,'pin {0} ({1}): double inversion (overline + pin type:Inverting)'.format(pin['name'], pin['num']))
 
-        return False if len(self.probably_wrong_pin_types) == 0 else True
+        return False if len(self.probably_wrong_pin_types)+len(self.double_inverted_pins) == 0 else True
 
     def fix(self):
         """
         Proceeds the fixing of the rule, if possible.
         """
-        if self.check():
-            for pin in self.probably_wrong_pin_types:
-                pin['electrical_type'] = 'W'
+        self.verboseOut(Verbosity.HIGH, Severity.INFO,"Fixing...")
+        for pin in self.probably_wrong_pin_types:
+            pin['electrical_type'] = 'W'
+
+        for pin in self.double_inverted_pins:
+            pin['pin_type']="" #reset pin type (removes dot at the base of pin)
+
+        self.recheck()

--- a/schlib/rules/EC02.py
+++ b/schlib/rules/EC02.py
@@ -27,6 +27,7 @@ class Rule(KLCRule):
                 # if group 2 is empty there are only letters in the pin name
                 if m.group(2) == '':
                     self.wrong_pin_numbers.append(pin)
+                    self.verboseOut(Verbosity.HIGH, Severity.WARNING, "pin: {0} number {1} is not valid, should contain at least 1 number".format(pin['name'], pin['num']))
 
         return False if len(self.wrong_pin_numbers) == 0 else True
 
@@ -34,5 +35,4 @@ class Rule(KLCRule):
         """
         Proceeds the fixing of the rule, if possible.
         """
-        if self.check():
-            pass
+        self.verboseOut(Verbosity.NORMAL, Severity.INFO, "FIX: not supported" )

--- a/schlib/rules/EC03.py
+++ b/schlib/rules/EC03.py
@@ -22,7 +22,7 @@ class Rule(KLCRule):
             * fp_is_missing
         """
 
-        # check if component has just one rectangle
+        # check if component has just one rectangle, if not, skip checking
         if len(self.component.draw['rectangles']) != 1: return False
 
         top = max(int(self.component.draw['rectangles'][0]['starty']), int(self.component.draw['rectangles'][0]['endy']))
@@ -32,64 +32,75 @@ class Rule(KLCRule):
 
         # if there is no pins in the top, the recommended position to ref is at top-center, horizontally centered
         if len(self.component.filterPins(direction='D')) == 0:
-            self.recommended_ref_pos = (0, top + 125)
+            self.recommended_ref_pos = {'posx':0,'posy':(top + 125)}
             self.recommended_ref_alignment = 'C'
 
         # otherwise, the recommended is put it before the first pin x position, right-aligned
         else:
             x = min([int(i['posx']) for i in self.component.filterPins(direction='D')]) - 100
-            self.recommended_ref_pos = (x, top + 125)
+            self.recommended_ref_pos = {'posx':x,'posy':(top + 125)}
             self.recommended_ref_alignment = 'R'
 
         # get the current reference infos and compare them to recommended ones
         ref_need_fix = False
-        pos = (int(self.component.fields[0]['posx']), int(self.component.fields[0]['posy']))
-        if (pos != self.recommended_ref_pos or
-            self.component.fields[0]['htext_justify'] != self.recommended_ref_alignment):
+        pos = {'posx':int(self.component.fields[0]['posx']), 'posy':int(self.component.fields[0]['posy'])}
+        if (pos != self.recommended_ref_pos):
+            self.verboseOut(Verbosity.HIGH, Severity.WARNING,"field: reference, {0}, recommended {1}".format(positionFormater(pos), positionFormater(self.recommended_ref_pos)))
             ref_need_fix = True
+        if (self.component.fields[0]['htext_justify'] != self.recommended_ref_alignment):
+            self.verboseOut(Verbosity.HIGH, Severity.WARNING,"field: reference, justification {0}, recommended {1}".format(self.component.fields[0]['htext_justify'],self.recommended_ref_alignment))
+            ref_need_fix = True
+        #Does vertical alignment matter too?
+        #What about orientation checking?
 
         ## name checking
 
         # if there is no pins in the top, the recommended position to name is at top-center, horizontally centered
         if len(self.component.filterPins(direction='D')) == 0:
-            self.recommended_name_pos = (0, top + 50)
+            self.recommended_name_pos = {'posx':0,'posy':(top + 50)}
             self.recommended_name_alignment = 'C'
 
         # otherwise, the recommended is put it before the first pin x position, right-aligned
         else:
             x = min([int(i['posx']) for i in self.component.filterPins(direction='D')]) - 100
-            self.recommended_name_pos = (x, top + 50)
+            self.recommended_name_pos = {'posx':x,'posy':(top + 50)}
             self.recommended_name_alignment = 'R'
 
         # get the current name infos and compare them to recommended ones
         name_need_fix = False
-        pos = (int(self.component.fields[1]['posx']), int(self.component.fields[1]['posy']))
-        if (pos != self.recommended_name_pos or
-            self.component.fields[1]['htext_justify'] != self.recommended_name_alignment):
+        pos = {'posx':int(self.component.fields[1]['posx']), 'posy':int(self.component.fields[1]['posy'])}
+        if (pos != self.recommended_name_pos):
+            self.verboseOut(Verbosity.HIGH, Severity.WARNING,"field: name, {0}, recommended {1}".format(positionFormater(pos), positionFormater(self.recommended_name_pos)))
             name_need_fix = True
-
+        if (self.component.fields[1]['htext_justify'] != self.recommended_name_alignment):
+            self.verboseOut(Verbosity.HIGH, Severity.WARNING,"field: name, justification {0}, recommended {1}".format(self.component.fields[1]['htext_justify'],self.recommended_name_alignment))
+            name_need_fix = True
         ## footprint checking
 
         # if there is no pins in the bottom, the recommended position to footprint is at bottom-center, horizontally centered
         if len(self.component.filterPins(direction='U')) == 0:
-            self.recommended_fp_pos = (0, bottom - 50)
+            self.recommended_fp_pos = {'posx':0,'posy':(bottom - 50)}
             self.recommended_fp_alignment = 'C'
 
         # otherwise, the recommended is put it after the last pin x position, left-aligned
         else:
             x = max([int(i['posx']) for i in self.component.filterPins(direction='U')]) + 50
-            self.recommended_fp_pos = (x, bottom - 50)
+            self.recommended_fp_pos = {'posx':x,'posy':(bottom - 50)}
             self.recommended_fp_alignment = 'L'
 
         # get the current footprint infos and compare them to recommended ones
         fp_need_fix = False
         self.fp_is_missing = False
         if len(self.component.fields) >= 3:
-            pos = (int(self.component.fields[2]['posx']), int(self.component.fields[2]['posy']))
-            if (pos != self.recommended_fp_pos or
-                self.component.fields[2]['htext_justify'] != self.recommended_fp_alignment):
+            pos = {'posx':int(self.component.fields[2]['posx']), 'posy':int(self.component.fields[2]['posy'])}
+            if (pos != self.recommended_fp_pos):
+                self.verboseOut(Verbosity.HIGH, Severity.WARNING,"field: footprint, {0}, recommended {1}".format( positionFormater(pos), positionFormater(self.recommended_fp_pos)))
+                fp_need_fix = True
+            if (self.component.fields[2]['htext_justify'] != self.recommended_fp_alignment):
+                self.verboseOut(Verbosity.HIGH, Severity.WARNING,"field: footprint, justification {0}, recommended {1}".format(self.component.fields[2]['htext_justify'],self.recommended_fp_alignment))
                 fp_need_fix = True
         else:
+            self.verboseOut(Verbosity.HIGH, Severity.WARNING,"field: footprint is missing, please re-save symbol using KiCad")
             fp_need_fix = True
             self.fp_is_missing = True
 
@@ -99,16 +110,18 @@ class Rule(KLCRule):
         """
         Proceeds the fixing of the rule, if possible.
         """
-        if self.check():
-            self.component.fields[0]['posx'] = str(self.recommended_ref_pos[0])
-            self.component.fields[0]['posy'] = str(self.recommended_ref_pos[1])
-            self.component.fields[0]['htext_justify'] = self.recommended_ref_alignment
+        self.verboseOut(Verbosity.HIGH, Severity.INFO,"Fixing...")
+        self.component.fields[0]['posx'] = str(self.recommended_ref_pos['posx'])
+        self.component.fields[0]['posy'] = str(self.recommended_ref_pos['posy'])
+        self.component.fields[0]['htext_justify'] = self.recommended_ref_alignment
 
-            self.component.fields[1]['posx'] = str(self.recommended_name_pos[0])
-            self.component.fields[1]['posy'] = str(self.recommended_name_pos[1])
-            self.component.fields[1]['htext_justify'] = self.recommended_name_alignment
+        self.component.fields[1]['posx'] = str(self.recommended_name_pos['posx'])
+        self.component.fields[1]['posy'] = str(self.recommended_name_pos['posy'])
+        self.component.fields[1]['htext_justify'] = self.recommended_name_alignment
 
-            if not self.fp_is_missing:
-                self.component.fields[2]['posx'] = str(self.recommended_fp_pos[0])
-                self.component.fields[2]['posy'] = str(self.recommended_fp_pos[1])
-                self.component.fields[2]['htext_justify'] = self.recommended_fp_alignment
+        if not self.fp_is_missing:
+            self.component.fields[2]['posx'] = str(self.recommended_fp_pos['posx'])
+            self.component.fields[2]['posy'] = str(self.recommended_fp_pos['posy'])
+            self.component.fields[2]['htext_justify'] = self.recommended_fp_alignment
+
+        self.recheck()

--- a/schlib/rules/EC04.py
+++ b/schlib/rules/EC04.py
@@ -15,21 +15,26 @@ class Rule(KLCRule):
         The following variables will be accessible after checking:
             * n_rectangles
         """
-
-        # check if component has just one rectangle
+        rectangle_need_fix = False
+        # check if component has just one rectangle, if not, skip checking
         self.n_rectangles = len(self.component.draw['rectangles'])
         if self.n_rectangles != 1: return False
 
-        if (self.component.draw['rectangles'][0]['thickness'] != '10' or
-            self.component.draw['rectangles'][0]['fill'] != 'f'):
-            return True
+        if (self.component.draw['rectangles'][0]['thickness'] != '10'):
+            self.verboseOut(Verbosity.HIGH,Severity.WARNING,"Component line thickness {0}, recommended {1}".format(self.component.draw['rectangles'][0]['thickness'],10))
+            rectangle_need_fix = True
+        if (self.component.draw['rectangles'][0]['fill'] != 'f'):
+            self.verboseOut(Verbosity.HIGH,Severity.WARNING,"Component background filled with {0} color, recommended is {1} color".format(backgroundFillToStr(self.component.draw['rectangles'][0]['fill']),backgroundFillToStr('f')))
+            rectangle_need_fix = True
 
-        return False
+        return True if rectangle_need_fix else False
 
     def fix(self):
         """
         Proceeds the fixing of the rule, if possible.
         """
-        if self.check():
-            self.component.draw['rectangles'][0]['thickness'] = '10'
-            self.component.draw['rectangles'][0]['fill'] = 'f'
+        self.verboseOut(Verbosity.HIGH, Severity.INFO,"Fixing...")
+        self.component.draw['rectangles'][0]['thickness'] = '10'
+        self.component.draw['rectangles'][0]['fill'] = 'f'
+
+        self.recheck()

--- a/schlib/rules/rule.py
+++ b/schlib/rules/rule.py
@@ -1,13 +1,30 @@
 # -*- coding: utf-8 -*-
 
+class Verbosity:
+    NONE=0
+    NORMAL=1
+    HIGH=2
+
+class Severity:
+    INFO=0
+    WARNING=1
+    ERROR=2
+    SUCCESS=3
+
 class KLCRule(object):
     """
     A base class to represent a KLC rule
     """
+
     def __init__(self, component, name, description):
         self.component = component
         self.name = name
         self.description = description
+        self.messageBuffer=[]
+
+    #adds message into buffer only if such level of verbosity is wanted
+    def verboseOut(self, msgVerbosity, severity, message):
+        self.messageBuffer.append([message,msgVerbosity,severity])
 
     def check(self, component):
         raise NotImplementedError('The check method must be implemented')

--- a/schlib/rules/rule.py
+++ b/schlib/rules/rule.py
@@ -1,5 +1,55 @@
 # -*- coding: utf-8 -*-
 
+#this should go to separate file
+def pinElecticalTypeToStr(pinEType):
+    pinMap={"I":"INPUT",\
+    "O":"OUTPUT",\
+    "B":"BIDI",\
+    "T":"TRISTATE",\
+    "P":"PASSIVE",\
+    "U":"UNSPECIFIED",\
+    "W":"POWER INPUT",\
+    "w":"POWER OUTPUT",\
+    "C":"OPEN COLLECTOR",\
+    "E":"OPEN EMITTER",\
+    "N":"NOT CONNECTED"}
+    if pinEType in pinMap.keys():
+        return pinMap[pinEType]
+    else:
+        return "INVALID"
+
+def pinTypeToStr(pinType):
+    pinMap={"I":"INVERTED",\
+    "C":"CLOCK",\
+    "CI":"INVERTED CLOCK",\
+    "L":"INPUT LOW",\
+    "CL":"CLOCK LOW",\
+    "V":"OUTPUT LOW",\
+    "F":"FALLING EDGE CLOCK",\
+    "X":"NON LOGIc"}
+    if pinType in pinMap.keys():
+        return pinMap[pinType]
+    else:
+        return "INVALID"
+
+def backgroundFillToStr(bgFill):
+    bgMap={
+    "F":"FOREGROUND",
+    "f":"BACKGROUND",
+    "N":"TRANSPARENT"}
+    if bgFill in bgMap.keys():
+        return bgMap[bgFill]
+    else:
+        return "INVALID"
+
+def positionFormater(element):
+    if type(element) != type({}):
+        raise Exception("input type: ",type(element),"expected dictionary, ",element)
+    if(not {"posx","posy"}.issubset(element.keys())):
+        raise Exception("missing keys 'posx' and 'posy' in"+str(element))
+    return "posx {0}, posy {1}".format(element['posx'],element['posy'])
+    # return "pos [{0},{1}]".format(element['posx'],element['posy'])
+
 class Verbosity:
     NONE=0
     NORMAL=1
@@ -31,3 +81,9 @@ class KLCRule(object):
 
     def fix(self, component):
         raise NotImplementedError('The fix method must be implemented')
+
+    def recheck(self):
+        if self.check():
+            self.verboseOut(Verbosity.HIGH, Severity.ERROR,"...could't be fixed")
+        else:
+            self.verboseOut(Verbosity.HIGH, Severity.SUCCESS,"everything fixed")

--- a/schlib/rules/rule3_1.py
+++ b/schlib/rules/rule3_1.py
@@ -21,7 +21,7 @@ class Rule(KLCRule):
             posy = int(pin['posy'])
             if (posx % 100) != 0 or (posy % 100) != 0:
                 self.violating_pins.append(pin)
-                self.verboseOut(Verbosity.HIGH, Severity.ERROR, 'pin: {0} ({1}), posx {2}, posy {3}'.format(pin['name'], pin['num'], pin['posx'], pin['posy']))
+                self.verboseOut(Verbosity.HIGH, Severity.ERROR, 'pin: {0} ({1}), {2}'.format(pin['name'], pin['num'], positionFormater(pin)))
 
         return True if len(self.violating_pins) > 0 else False
 

--- a/schlib/rules/rule3_1.py
+++ b/schlib/rules/rule3_1.py
@@ -21,8 +21,7 @@ class Rule(KLCRule):
             posy = int(pin['posy'])
             if (posx % 100) != 0 or (posy % 100) != 0:
                 self.violating_pins.append(pin)
-                self.verboseOut(Verbosity.HIGH, Severity.ERROR, 'pin: %s (%s), posx %s, posy %s' %
-                           (pin['name'], pin['num'], pin['posx'], pin['posy']))
+                self.verboseOut(Verbosity.HIGH, Severity.ERROR, 'pin: {0} ({1}), posx {2}, posy {3}'.format(pin['name'], pin['num'], pin['posx'], pin['posy']))
 
         return True if len(self.violating_pins) > 0 else False
 

--- a/schlib/rules/rule3_1.py
+++ b/schlib/rules/rule3_1.py
@@ -21,6 +21,8 @@ class Rule(KLCRule):
             posy = int(pin['posy'])
             if (posx % 100) != 0 or (posy % 100) != 0:
                 self.violating_pins.append(pin)
+                self.verboseOut(Verbosity.HIGH, Severity.ERROR, 'pin: %s (%s), posx %s, posy %s' %
+                           (pin['name'], pin['num'], pin['posx'], pin['posy']))
 
         return True if len(self.violating_pins) > 0 else False
 
@@ -28,6 +30,5 @@ class Rule(KLCRule):
         """
         Proceeds the fixing of the rule, if possible.
         """
-        if self.check():
-            pass
-            # TODO
+        self.verboseOut(Verbosity.NORMAL, Severity.INFO, "FIX: not yet supported" )
+        # TODO

--- a/schlib/rules/rule3_2.py
+++ b/schlib/rules/rule3_2.py
@@ -21,6 +21,8 @@ class Rule(KLCRule):
             if length == 0: continue
             if (length < 100) or (length % 50 != 0):
                 self.violating_pins.append(pin)
+                self.verboseOut(Verbosity.HIGH, Severity.ERROR, 'pin: %s (%s), posx %s, posy %s' %
+                           (pin['name'], pin['num'], pin['posx'], pin['posy']))
 
         return True if len(self.violating_pins) > 0 else False
 
@@ -28,6 +30,5 @@ class Rule(KLCRule):
         """
         Proceeds the fixing of the rule, if possible.
         """
-        if self.check():
-            pass
-            # TODO
+        self.verboseOut(Verbosity.NORMAL, Severity.INFO, "FIX: not yet supported" )
+        # TODO

--- a/schlib/rules/rule3_2.py
+++ b/schlib/rules/rule3_2.py
@@ -21,8 +21,7 @@ class Rule(KLCRule):
             if length == 0: continue
             if (length < 100) or (length % 50 != 0):
                 self.violating_pins.append(pin)
-                self.verboseOut(Verbosity.HIGH, Severity.ERROR, 'pin: %s (%s), posx %s, posy %s' %
-                           (pin['name'], pin['num'], pin['posx'], pin['posy']))
+                self.verboseOut(Verbosity.HIGH, Severity.ERROR, 'pin: {0} ({1}), posx {2}, posy {3}'.format(pin['name'], pin['num'], pin['posx'], pin['posy']))
 
         return True if len(self.violating_pins) > 0 else False
 

--- a/schlib/rules/rule3_2.py
+++ b/schlib/rules/rule3_2.py
@@ -21,7 +21,7 @@ class Rule(KLCRule):
             if length == 0: continue
             if (length < 100) or (length % 50 != 0):
                 self.violating_pins.append(pin)
-                self.verboseOut(Verbosity.HIGH, Severity.ERROR, 'pin: {0} ({1}), posx {2}, posy {3}'.format(pin['name'], pin['num'], pin['posx'], pin['posy']))
+                self.verboseOut(Verbosity.HIGH, Severity.ERROR, 'pin: {0} ({1}), {2}'.format(pin['name'], pin['num'], positionFormater(pin)))
 
         return True if len(self.violating_pins) > 0 else False
 

--- a/schlib/rules/rule3_6.py
+++ b/schlib/rules/rule3_6.py
@@ -21,13 +21,14 @@ class Rule(KLCRule):
             text_size = int(field['text_size'])
             if (text_size != 50):
                 self.violating_fields.append(field)
-                keys=field.keys()
-                message=""
-                if("reference" in keys):
-                    message+=field["reference"]
+                if("reference" in field.keys()):
+                    message=field["reference"][1:-1]
+                elif (len(field["name"])>2):
+                    message=field["name"][1:-1]
                 else:
-                    message+=field["name"]
-                self.verboseOut(Verbosity.HIGH, Severity.ERROR,"field: "+message+" size"+field["text_size"])
+                    message="UNKNOWN"
+                message+=(" at posx {0} posy {1}".format(field["posx"],field["posy"]))
+                self.verboseOut(Verbosity.HIGH, Severity.ERROR,"field: {0} size {1}".format(message,field["text_size"]) )
 
 
         self.violating_pins = []
@@ -36,8 +37,7 @@ class Rule(KLCRule):
             num_text_size = int(pin['num_text_size'])
             if (name_text_size != 50) or (num_text_size != 50):
                 self.violating_pins.append(pin)
-                self.verboseOut(Verbosity.HIGH, Severity.ERROR, 'pin: %s (%s), text size %s, number size %s' %
-                           (pin['name'], pin['num'], pin['name_text_size'], pin['num_text_size']))
+                self.verboseOut(Verbosity.HIGH, Severity.ERROR, 'pin: {0} ({1}), text size {2}, number size {3}'.format(pin['name'], pin['num'], pin['name_text_size'], pin['num_text_size']))
 
         if (len(self.violating_fields) > 0 or
             len(self.violating_pins) > 0):

--- a/schlib/rules/rule3_6.py
+++ b/schlib/rules/rule3_6.py
@@ -56,9 +56,6 @@ class Rule(KLCRule):
         for pin in self.violating_pins:
             pin['name_text_size'] = '50'
             pin['num_text_size'] = '50'
-        if self.check():
-            self.verboseOut(Verbosity.HIGH, Severity.ERROR,"...could't be fixed")
-        else:
-            self.verboseOut(Verbosity.HIGH, Severity.SUCCESS,"everything fixed")
+        self.recheck()
 
 

--- a/schlib/rules/rule3_6.py
+++ b/schlib/rules/rule3_6.py
@@ -21,6 +21,14 @@ class Rule(KLCRule):
             text_size = int(field['text_size'])
             if (text_size != 50):
                 self.violating_fields.append(field)
+                keys=field.keys()
+                message=""
+                if("reference" in keys):
+                    message+=field["reference"]
+                else:
+                    message+=field["name"]
+                self.verboseOut(Verbosity.HIGH, Severity.ERROR,"field: "+message+" size"+field["text_size"])
+
 
         self.violating_pins = []
         for pin in self.component.pins:
@@ -28,6 +36,8 @@ class Rule(KLCRule):
             num_text_size = int(pin['num_text_size'])
             if (name_text_size != 50) or (num_text_size != 50):
                 self.violating_pins.append(pin)
+                self.verboseOut(Verbosity.HIGH, Severity.ERROR, 'pin: %s (%s), text size %s, number size %s' %
+                           (pin['name'], pin['num'], pin['name_text_size'], pin['num_text_size']))
 
         if (len(self.violating_fields) > 0 or
             len(self.violating_pins) > 0):
@@ -39,10 +49,16 @@ class Rule(KLCRule):
         """
         Proceeds the fixing of the rule, if possible.
         """
-        if self.check():
-            for field in self.violating_fields:
-                field['text_size'] = '50'
+        self.verboseOut(Verbosity.HIGH, Severity.INFO,"Fixing...")
+        for field in self.violating_fields:
+            field['text_size'] = '50'
 
-            for pin in self.violating_pins:
-                pin['name_text_size'] = '50'
-                pin['num_text_size'] = '50'
+        for pin in self.violating_pins:
+            pin['name_text_size'] = '50'
+            pin['num_text_size'] = '50'
+        if self.check():
+            self.verboseOut(Verbosity.HIGH, Severity.ERROR,"...could't be fixed")
+        else:
+            self.verboseOut(Verbosity.HIGH, Severity.SUCCESS,"everything fixed")
+
+

--- a/schlib/rules/rule3_8.py
+++ b/schlib/rules/rule3_8.py
@@ -16,27 +16,32 @@ class Rule(KLCRule):
             * only_datasheet_missing
         """
 
-        self.only_datasheet_missing = False
+        self.only_datasheet_missing=False #unused, remove?
 
-        if not self.component.documentation: return True
+        if not self.component.documentation:
+            self.verboseOut(Verbosity.HIGH,Severity.ERROR,"missing whole documentation (description, keywords, datasheet)")
+            return True
 
-        if (not self.component.documentation['description'] or
+        elif (not self.component.documentation['description'] or
             not self.component.documentation['keywords'] or
             not self.component.documentation['datasheet']):
 
-            if (self.component.documentation['description'] and
-                self.component.documentation['keywords'] and
-                not self.component.documentation['datasheet']):
-                self.only_datasheet_missing = True
-
+            if (not self.component.documentation['description']):
+                self.verboseOut(Verbosity.HIGH,Severity.ERROR,"missing description")
+            if (not self.component.documentation['keywords']):
+                self.verboseOut(Verbosity.HIGH,Severity.ERROR,"missing keywords")
+            if (not self.component.documentation['datasheet']):
+                self.verboseOut(Verbosity.HIGH,Severity.WARNING,"missing datasheet, please provide a datasheet link if it isn't a generic component")
+                if (self.component.documentation['description'] and
+                    self.component.documentation['keywords']):
+                    self.only_datasheet_missing=True
             return True
 
-        return False
+        else:
+            return False
 
     def fix(self):
         """
         Proceeds the fixing of the rule, if possible.
         """
-        if self.check():
-            # Can't fix that!
-            pass
+        self.verboseOut(Verbosity.NORMAL, Severity.INFO, "FIX: not supported" )


### PR DESCRIPTION
Improved way how to generate verbose output.
Now each rule script fills its own message buffer with success/info/warning/error messages. checklib.py then selects which to print and how to colorize them. (each message has verbosity and severity flag)
All scripts have message for each detected problem. So no more guessing what could be wrong.

Scripts were tested on KiCad library.

These changes makes a lot of variables unused. Then could be removed in future.

This PR resolves #17 