### PR TITLE
Preserve line ordering

### DIFF
--- a/schlib/rules/rule3_8.py
+++ b/schlib/rules/rule3_8.py
@@ -18,27 +18,44 @@ class Rule(KLCRule):
 
         self.only_datasheet_missing=False #unused, remove?
 
-        if not self.component.documentation:
-            self.verboseOut(Verbosity.HIGH,Severity.ERROR,"missing whole documentation (description, keywords, datasheet)")
+        invalid_documentation=0
+        #check part itself
+        if self.checkDocumentation(self.component.documentation): invalid_documentation+=1
+
+        #check all its aliases too
+        if self.component.aliases:
+            for alias in self.component.aliases.keys():
+                self.verboseOut(Verbosity.HIGH,Severity.INFO,"checking alias: {0}".format(alias))
+                if self.checkDocumentation(self.component.aliases[alias], indentation=2):
+                    invalid_documentation+=1
+
+        return True if invalid_documentation>0 else False
+
+
+    def checkDocumentation(self, documentation, indentation=0):
+        if not documentation:
+            self.verboseOut(Verbosity.HIGH,Severity.ERROR," "*indentation+"missing whole documentation (description, keywords, datasheet)")
             return True
 
-        elif (not self.component.documentation['description'] or
-            not self.component.documentation['keywords'] or
-            not self.component.documentation['datasheet']):
+        elif (not documentation['description'] or
+            not documentation['keywords'] or
+            not documentation['datasheet']):
 
-            if (not self.component.documentation['description']):
-                self.verboseOut(Verbosity.HIGH,Severity.ERROR,"missing description")
-            if (not self.component.documentation['keywords']):
-                self.verboseOut(Verbosity.HIGH,Severity.ERROR,"missing keywords")
-            if (not self.component.documentation['datasheet']):
-                self.verboseOut(Verbosity.HIGH,Severity.WARNING,"missing datasheet, please provide a datasheet link if it isn't a generic component")
-                if (self.component.documentation['description'] and
-                    self.component.documentation['keywords']):
+            if (not documentation['description']):
+                self.verboseOut(Verbosity.HIGH,Severity.ERROR," "*indentation+"missing description")
+            if (not documentation['keywords']):
+                self.verboseOut(Verbosity.HIGH,Severity.ERROR," "*indentation+"missing keywords")
+            if (not documentation['datasheet']):
+                self.verboseOut(Verbosity.HIGH,Severity.WARNING," "*indentation+"missing datasheet, please provide a datasheet link if it isn't a generic component")
+                if (documentation['description'] and
+                    documentation['keywords']):
                     self.only_datasheet_missing=True
             return True
 
         else:
+            self.verboseOut(Verbosity.HIGH,Severity.SUCCESS," "*indentation+"documentation OK")
             return False
+
 
     def fix(self):
         """

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -318,13 +318,9 @@ class SchLib(object):
                 keys_list = Component._DRAW_KEYS[elem[0]]# 'A' -> keys of all properties of arc
                 line = elem[0] + ' '# 'arcs' -> 'A'
                 for k in keys_list:
-                    if k == 'italic':
-                        line += ' '#for unknown reason, KiCad adds space in front of Italic/Normal parameter (https://github.com/KiCad/kicad-source-mirror/blob/master/eeschema/lib_text.cpp#L77)
                     if k == 'points':
-                        points=item['points']
-                        for i in range(0,len(points)-1,2):
-                            # x and y pairs have spaces on both sides -> "... x1 y1  x2 y2 ..."
-                            line += ' {0} {1} '.format(points[i],points[i+1])
+                        for i in item['points']:
+                            line += '{0} '.format(i)
                     else:
                         line += item[k] + ' '
 

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -67,8 +67,8 @@ class Component(object):
     _TEXT_KEYS = ['direction','posx','posy','text_size','text_type','unit','convert','text', 'italic', 'bold', 'hjustify', 'vjustify']
     _PIN_KEYS = ['name','num','posx','posy','length','direction','name_text_size','num_text_size','unit','convert','electrical_type','pin_type']
 
-    _DRAW_KEYS = {'arcs':_ARC_KEYS, 'circles':_CIRCLE_KEYS, 'polylines':_POLY_KEYS, 'rectangles':_RECT_KEYS, 'texts':_TEXT_KEYS, 'pins':_PIN_KEYS}
-    _DRAW_ELEMS = {'arcs':'A', 'circles':'C', 'polylines':'P', 'rectangles':'S', 'texts':'T', 'pins':'X'}
+    _DRAW_KEYS = {'A':_ARC_KEYS, 'C':_CIRCLE_KEYS, 'P':_POLY_KEYS, 'S':_RECT_KEYS, 'T':_TEXT_KEYS, 'X':_PIN_KEYS}
+    # _DRAW_ELEMS = {'arcs':'A', 'circles':'C', 'polylines':'P', 'rectangles':'S', 'texts':'T', 'pins':'X'}
 
     _KEYS = {'DEF':_DEF_KEYS, 'F0':_F0_KEYS, 'F':_FN_KEYS,
              'A':_ARC_KEYS, 'C':_CIRCLE_KEYS, 'P':_POLY_KEYS, 'S':_RECT_KEYS, 'T':_TEXT_KEYS, 'X':_PIN_KEYS}
@@ -122,6 +122,7 @@ class Component(object):
                     'texts':[],
                     'pins':[]
                 }
+                self.drawOrdered=[]#list of draw elements references, needed to preserve line ordering
 
             elif line[0] == 'ENDDRAW':
                 building_draw = False
@@ -133,9 +134,11 @@ class Component(object):
                 elif building_draw:
                     if line[0] == 'A':
                         self.draw['arcs'].append(dict(zip(self._ARC_KEYS,values)))
+                        self.drawOrdered.append(['A',self.draw['arcs'][-1]])
                     if line[0] == 'C':
                         self.draw['circles'].append(dict(zip(self._CIRCLE_KEYS,values)))
-                    if line[0] == 'P':
+                        self.drawOrdered.append(['C',self.draw['circles'][-1]])
+                    if line[0] == 'P':#mixing X an Y points into 1 list in not handy
                         n_points = int(line[1])
                         points = line[5:5+(2*n_points)]
                         values = line[1:5] + [points]
@@ -144,12 +147,17 @@ class Component(object):
                         else:
                             values += ['']
                         self.draw['polylines'].append(dict(zip(self._POLY_KEYS,values)))
+                        self.drawOrdered.append(['P',self.draw['polylines'][-1]])
                     if line[0] == 'S':
                         self.draw['rectangles'].append(dict(zip(self._RECT_KEYS,values)))
+                        self.drawOrdered.append(['S',self.draw['rectangles'][-1]])
                     if line[0] == 'T':
                         self.draw['texts'].append(dict(zip(self._TEXT_KEYS,values)))
+                        self.drawOrdered.append(['T',self.draw['texts'][-1]])
                     if line[0] == 'X':
                         self.draw['pins'].append(dict(zip(self._PIN_KEYS,values)))
+                        self.drawOrdered.append(['X',self.draw['pins'][-1]])
+
 
         # define some shortcuts
         self.name = self.definition['name']
@@ -303,21 +311,21 @@ class SchLib(object):
 
             # DRAW
             to_write.append('DRAW\n')
-            for elem in component.draw.items():
-                for item in component.draw[elem[0]]:
-                    keys_list = Component._DRAW_KEYS[elem[0]]
-                    line = Component._DRAW_ELEMS[elem[0]] + ' '
-                    for k in keys_list:
-                        if k == 'points':
-                            points=item['points']
-                            for i in range(0,len(points)-1,2):
-                                # x and y pairs have spaces on both sides -> "... x1 y1  x2 y2 ..."
-                                line += ' {0} {1} '.format(points[i],points[i+1])
-                        else:
-                            line += item[k] + ' '
+            for elem in component.drawOrdered:
+                item=elem[1]
+                keys_list = Component._DRAW_KEYS[elem[0]]# 'A' -> keys of all properties of arc
+                line = elem[0] + ' '# 'arcs' -> 'A'
+                for k in keys_list:
+                    if k == 'points':
+                        points=item['points']
+                        for i in range(0,len(points)-1,2):
+                            # x and y pairs have spaces on both sides -> "... x1 y1  x2 y2 ..."
+                            line += ' {0} {1} '.format(points[i],points[i+1])
+                    else:
+                        line += item[k] + ' '
 
-                    line = line.rstrip() + '\n'
-                    to_write.append(line)
+                line = line.rstrip() + '\n'
+                to_write.append(line)
 
             # ENDDRAW
             to_write.append('ENDDRAW\n')

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -75,7 +75,7 @@ class Component(object):
     def __init__(self, data, comments, documentation):
         self.comments = comments
         self.fplist = []
-        self.aliases = []
+        self.aliases = {}
         building_fplist = False
         building_draw = False
         for line in data:
@@ -102,7 +102,8 @@ class Component(object):
                 self.fields.append(dict(zip(self._FN_KEYS,values)))
 
             elif line[0] == 'ALIAS':
-                self.aliases = [alias for alias in line[1:]]
+                for alias in line[1:]:
+                    self.aliases[alias]=self.getDocumentation(documentation,alias)
 
             elif line[0] == '$FPLIST':
                 building_fplist = True
@@ -156,10 +157,13 @@ class Component(object):
         self.pins = self.draw['pins']
 
         # get documentation
+        self.documentation = self.getDocumentation(documentation,self.name)
+
+    def getDocumentation(self,documentation,name):
         try:
-            self.documentation = documentation.components[self.name]
+            return documentation.components[name]
         except KeyError:
-            self.documentation = {}
+            return {}
 
     def getPinsByName(self, name):
         pins = []

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -309,8 +309,10 @@ class SchLib(object):
                     line = Component._DRAW_ELEMS[elem[0]] + ' '
                     for k in keys_list:
                         if k == 'points':
-                            for i in item['points']:
-                                line += i + ' '
+                            points=item['points']
+                            for i in range(0,len(points)-1,2):
+                                # x and y pairs have spaces on both sides -> "... x1 y1  x2 y2 ..."
+                                line += ' {0} {1} '.format(points[i],points[i+1])
                         else:
                             line += item[k] + ' '
 

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -76,6 +76,7 @@ class Component(object):
         self.comments = comments
         self.fplist = []
         self.aliases = {}
+        self.aliasesOrdered =[]
         building_fplist = False
         building_draw = False
         for line in data:
@@ -103,6 +104,7 @@ class Component(object):
 
             elif line[0] == 'ALIAS':
                 for alias in line[1:]:
+                    self.aliasesOrdered.append(alias)
                     self.aliases[alias]=self.getDocumentation(documentation,alias)
 
             elif line[0] == '$FPLIST':
@@ -294,7 +296,7 @@ class SchLib(object):
             # ALIAS
             if len(component.aliases) > 0:
                 line = 'ALIAS '
-                for alias in component.aliases:
+                for alias in component.aliasesOrdered:
                     line += alias + ' '
 
                 line = line.rstrip() + '\n'

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -318,6 +318,8 @@ class SchLib(object):
                 keys_list = Component._DRAW_KEYS[elem[0]]# 'A' -> keys of all properties of arc
                 line = elem[0] + ' '# 'arcs' -> 'A'
                 for k in keys_list:
+                    if k == 'italic':
+                        line += ' '#for unknown reason, KiCad adds space in front of Italic/Normal parameter (https://github.com/KiCad/kicad-source-mirror/blob/master/eeschema/lib_text.cpp#L77)
                     if k == 'points':
                         points=item['points']
                         for i in range(0,len(points)-1,2):


### PR DESCRIPTION
This PR follows PR #21 and closes issue #22.  Line order is preserved and formatting matches KiCad's output. This was problem of DRAW part of symbol.
*note: Kicad may reorder lines if they are ordered in different way than he likes it. But checklib.py does not touch their order anymore.*

**test**
Tested on atmel library. I tried --fix on some valid component and resulting file makes exactly same changes as resaving library in KiCad.