### PR TITLE
Vizualising variant BOMs

### DIFF
--- a/sch/variant.py
+++ b/sch/variant.py
@@ -8,7 +8,11 @@ def variant(mysch, key_field, nopop_flag="NP"):
     for comp in mysch.components:
         fields = [ f['ref'] for f in comp.fields if f['name'] == kf]
         if len(fields)>0 and fields[0] == npop:
-            comp.labels["name"] = comp.labels["name"] + "_NOPOP"
+            if not comp.labels["name"].endswith("_NOPOP"):
+                comp.labels["name"] = comp.labels["name"] + "_NOPOP"
+        else:
+            if comp.labels["name"].endswith("_NOPOP"):
+                comp.labels["name"] = comp.labels["name"][:-6]
     def change_title(line):
         if line.startswith("Title"):
             line_fields = line.split('"')
@@ -16,7 +20,10 @@ def variant(mysch, key_field, nopop_flag="NP"):
                 previous_title = line_fields[1]
             else:
                 previous_title = ""
-            title = previous_title + " - " + key_field + " variant"
+            if not previous_title.endswith("variant"):
+                title = previous_title + " - " + key_field + " variant"
+            else:
+                title = previous_title
             line = 'Title "{}"\n'.format(title)
         return line
     mysch.description.raw_data = [change_title(line) for line in mysch.description.raw_data] 

--- a/sch/variant.py
+++ b/sch/variant.py
@@ -9,6 +9,17 @@ def variant(mysch, key_field, nopop_flag="NP"):
         fields = [ f['ref'] for f in comp.fields if f['name'] == kf]
         if len(fields)>0 and fields[0] == npop:
             comp.labels["name"] = comp.labels["name"] + "_NOPOP"
+    def change_title(line):
+        if line.startswith("Title"):
+            line_fields = line.split('"')
+            if len(line_fields)>1:
+                previous_title = line_fields[1]
+            else:
+                previous_title = ""
+            title = previous_title + " - " + key_field + " variant"
+            line = 'Title "{}"\n'.format(title)
+        return line
+    mysch.description.raw_data = [change_title(line) for line in mysch.description.raw_data] 
             
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="change parts in schematic to reflect not variant BOM. You should have run create_nopop on the cache lib of the project before.")

--- a/sch/variant.py
+++ b/sch/variant.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+import argparse
+import sch
+
+def variant(mysch, key_field, nopop_flag="NP"):
+    kf = '"' + key_field + '"'
+    npop = '"' + nopop_flag + '"'
+    for comp in mysch.components:
+        fields = [ f['ref'] for f in comp.fields if f['name'] == kf]
+        if len(fields)>0 and fields[0] == npop:
+            comp.labels["name"] = comp.labels["name"] + "_NOPOP"
+            
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="change parts in schematic to reflect not variant BOM. You should have run create_nopop on the cache lib of the project before.")
+    parser.add_argument("schematic")
+    parser.add_argument('--key', dest='key', required=True,
+                   help='key field for defining no pop')
+    parser.add_argument('--nopop', dest="nopop_flag", default="NP",
+                        help="value indicating that part is not populated")
+    args = parser.parse_args()
+
+    mysch = sch.Schematic(args.schematic)
+    variant(mysch, key_field=args.key, nopop_flag=args.nopop_flag)
+    mysch.save()

--- a/schlib/create_nopop.py
+++ b/schlib/create_nopop.py
@@ -1,0 +1,97 @@
+import argparse
+import schlib
+import copy
+from math import cos, sin, ceil
+
+
+def rect_bounds(r):
+    startx = int(r['startx'])
+    starty = int(r['starty'])
+    endx   = int(r['endx'  ])
+    endy   = int(r['endy'  ])
+    return [min(startx, endx), min(starty, endy), max(startx, endx), max(starty, endy)]
+
+def poly_bounds(p):
+    flat_points = p["points"]
+    points = [[int(flat_points[i]),int(flat_points[i+1])] for i in range(0, len(flat_points), 2)]
+    coords = zip(*points)
+    return [min(coords[0]), min(coords[1]), max(coords[0]), max(coords[1])]
+
+def circle_bounds(c):
+    posx    = int(c['posx'  ])
+    posy    = int(c['posy'  ])
+    radius  = int(c['radius'])
+    return [posx - radius, posy - radius, posx + radius, posy + radius]
+
+def arc_bounds(a):
+    posx        = int(a['posx'])
+    posy        = int(a['posy'])
+    radius      = int(a['radius'])
+    start_angle = float(a['start_angle'])/10.0
+    end_angle   = float(a['end_angle'])/10.0
+    start_point = [posx + int(radius*cos(start_angle)), posy + int(radius*sin(start_angle))]
+    end_point   = [posx + int(radius*cos(end_angle)), posy + int(radius*sin(end_angle))]
+    closest_right_end = ceil(end_angle/90.0)*90.0
+    points = [start_point, end_point]
+    while closest_right_end < end_angle:
+        points.append([[posx + int(radius*cos(closest_right_end)), posy + int(radius*sin(closest_right_end))]])
+        closest_right_end = closest_right_end + 90.0
+    coords = zip(*points)
+    return [min(coords[0]), min(coords[1]), max(coords[0]), max(coords[1])]
+
+def pin_bounds(p):
+    posx      = int(p['posx'     ])
+    posy      = int(p['posy'     ])
+    length    = int(p['length'   ])
+    direction = p['direction']
+    if direction == 'D':
+        return [posx, posy - length, posx, posy]
+    elif direction == 'U':
+        return [posx, posy, posx, posy + length]
+    elif direction == 'L':
+        return [posx - length, posy, posx, posy]
+    else:
+        return [posx, posy, posx + length, posy]
+
+def cross_nopop(component, rect):
+    name = component.name
+    component.name = name + "_NOPOP"
+    component.definition["name"]= component.name
+    component.fields[1]["name"] = '"' + component.name + '"'
+    component.aliasesOrdered = [ a+ "_NOPOP" for a in component.aliasesOrdered]
+    values = [ '2', '0', '1', '50', [str(rect[0]), str(rect[1]), str(rect[2]), str(rect[3])], "N"]
+    component.draw['polylines'].append(dict(zip(component._POLY_KEYS,values)))
+    component.drawOrdered.append(['P',component.draw['polylines'][-1]])
+    values = [ '2', '0', '1', '50', [str(rect[0]), str(rect[3]), str(rect[2]), str(rect[1])], "N"]
+    component.draw['polylines'].append(dict(zip(component._POLY_KEYS,values)))
+    component.drawOrdered.append(['P', component.draw['polylines'][-1]])
+
+def compute_boundaries(npcomp):
+    boundaries = [[0, 0, 0, 0]]
+    boundaries.extend([rect_bounds(r) for r in npcomp.draw["rectangles"]])
+    boundaries.extend([poly_bounds(p) for p in npcomp.draw["polylines"]])
+    boundaries.extend([circle_bounds(c) for c in npcomp.draw["circles"]])
+    boundaries.extend([arc_bounds(a) for a in npcomp.draw["arcs"]])
+    boundaries.extend([pin_bounds(p) for p in npcomp.draw["pins"]])
+    coords = zip(*boundaries)
+    rect = (min(coords[0]), min(coords[1]), max(coords[2]), max(coords[3]))
+    return rect
+    
+def action(mylib, nopop=cross_nopop):
+    # Not idempotent!
+    for component in mylib.components:
+        if not component.name.endswith("_NOPOP") and component.definition["reference"]!="#PWR" :
+            npcomp = copy.deepcopy(component)
+            rect = compute_boundaries(npcomp)
+            nopop(npcomp, rect)
+            mylib.components.append(npcomp)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("libname")
+
+    args = parser.parse_args()
+
+    mylib = schlib.SchLib(args.libname)
+    action(mylib)
+    mylib.save()

--- a/schlib/create_nopop.py
+++ b/schlib/create_nopop.py
@@ -78,13 +78,15 @@ def compute_boundaries(npcomp):
     return rect
     
 def action(mylib, nopop=cross_nopop):
-    # Not idempotent!
-    for component in mylib.components:
-        if not component.name.endswith("_NOPOP") and component.definition["reference"]!="#PWR" :
-            npcomp = copy.deepcopy(component)
-            rect = compute_boundaries(npcomp)
-            nopop(npcomp, rect)
-            mylib.components.append(npcomp)
+    components_names = set([c.name for c in mylib.components if c.definition["reference"] != "#PWR"])
+    pop_set, nopop_set = set(), set()
+    for c in components_names:
+        nopop_set.add(c[:-6]) if c.endswith("_NOPOP") else pop_set.add(c)
+    for c_name in pop_set - nopop_set:
+        npcomp = copy.deepcopy(mylib.getComponentByName(c_name))
+        rect = compute_boundaries(npcomp)
+        nopop(npcomp, rect)
+        mylib.components.append(npcomp)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Variant BOM can be visualized in schematics with the two scripts introduced in this PR.

A first script in schlib `create_nopop.py`, can be applied to the -cache.lib library to create duplicated parts with a big cross on them. These new parts'names are appended with "_NOPOP".

Then, you can apply the second script on the sch files. This script will change the part's symbol to nopop if a given field matches a given value, eg "NP". If you have defined some fields named according to the variant BOM and filled with the given "NP" value when the part should not be populated in this variant, the new schematic file will reflect the variant with crossed parts when not populated.

Be careful that these scripts are "destructive". You should have backed up the project or commited the latest version in you favorite version control system.
