### PR TITLE
Windows fixes

### DIFF
--- a/pcb/check_kicad_mod.py
+++ b/pcb/check_kicad_mod.py
@@ -4,8 +4,15 @@ from __future__ import print_function
 
 import argparse
 from kicad_mod import *
+import sys, os
+#point to the correct location for the print_color script
+sys.path.append(os.path.join(sys.path[0],'..','schlib'))
+
 from print_color import *
 from rules import *
+
+#enable windows wildcards
+from glob import glob
 
 parser = argparse.ArgumentParser()
 parser.add_argument('kicad_mod_files', nargs='+')
@@ -22,7 +29,12 @@ for f in dir():
     if f.startswith('rule'):
         all_rules.append(globals()[f].Rule)
 
-for filename in args.kicad_mod_files:
+files = []
+
+for f in args.kicad_mod_files:
+    files += glob(f)
+        
+for filename in files:
     module = KicadMod(filename)
     printer.green('checking module: %s' % module.name)
 

--- a/pcb/print_color.py
+++ b/pcb/print_color.py
@@ -1,1 +1,0 @@
-../schlib/print_color.py

--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -6,6 +6,9 @@ from schlib import *
 from print_color import *
 from rules import *
 
+#enable windows wildcards
+from glob import glob
+
 def processVerboseOutput(messageBuffer):
     if args.verbose:
         for msg in messageBuffer:
@@ -47,7 +50,13 @@ for f in dir():
     if f.startswith('EC'):
         all_ec.append(globals()[f].Rule)
 
+#grab list of libfiles (even on windows!)
+libfiles = []
+
 for libfile in args.libfiles:
+    libfiles += glob(libfile)
+
+for libfile in libfiles:
     lib = SchLib(libfile)
     n_components = 0
     printer.purple('library: %s' % libfile)


### PR DESCRIPTION
This PR makes some subtle changes to the checklib.py and check_kicad_mod.py scripts to allow them to work better under windows.

* Enable wildcard support - Windows does not have command-line wildcard support by default.
* Fixed reference to *print_color.py* in *check_kicad_mod.py* - Python under windows doesn't support running external scripts in this fashion.

Please check that both of these scripts still perform as intended under *nix