### PR TITLE
Fix schlib.py andmove_part.py to move components properly

### DIFF
--- a/schlib/move_part.py
+++ b/schlib/move_part.py
@@ -35,40 +35,12 @@ for comp in dst_lib.components:
         sys.exit(1)
 
 # append component to destination and save
-dst_lib.components.append(component)
+dst_lib.addComponent(component)
 dst_lib.save()
 
 # remove component from source and save
-src_lib.components.remove(component)
+src_lib.removeComponent(component.name)
 src_lib.save()
-
-if component.documentation:
-    i = component.documentation['lines_range']['start']
-    j = component.documentation['lines_range']['end'] + 1
-
-# remove documentation from source
-src_lines = []
-try:
-    f = open(src_lib.documentation_filename, 'r')
-    src_lines = f.readlines()
-    f = open(src_lib.documentation_filename, 'w')
-    f.writelines(src_lines[:i] + src_lines[j:])
-    f.close()
-except FileNotFoundError:
-    pass
-
-# add documentation to destination
-if src_lines:
-    try:
-        f = open(dst_lib.documentation_filename, 'r')
-        dst_lines = f.readlines()
-    except FileNotFoundError:
-        dst_lines = ['EESchema-DOCLIB  Version 2.0\n', '#\n', '#End Doc Library\n']
-
-    dst_lines[-2:-2] = src_lines[i:j]
-    f = open(dst_lib.documentation_filename, 'w')
-    f.writelines(dst_lines)
-    f.close()
 
 print('Component "%s" moved.'  % (args.name))
 print('Please, before commit use git diff to check if everything is ok.')

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -107,8 +107,7 @@ class Component(object):
     def __init__(self, data, comments, documentation):
         self.comments = comments
         self.fplist = []
-        self.aliases = {}
-        self.aliasesOrdered =[]
+        self.aliases = OrderedDict()
         building_fplist = False
         building_draw = False
         for line in data:
@@ -136,7 +135,6 @@ class Component(object):
 
             elif line[0] == 'ALIAS':
                 for alias in line[1:]:
-                    self.aliasesOrdered.append(alias)
                     self.aliases[alias]=self.getDocumentation(documentation,alias)
 
             elif line[0] == '$FPLIST':
@@ -328,7 +326,7 @@ class SchLib(object):
             # ALIAS
             if len(component.aliases) > 0:
                 line = 'ALIAS '
-                for alias in component.aliasesOrdered:
+                for alias in component.aliases.keys():
                     line += alias + ' '
 
                 line = line.rstrip() + '\n'

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -92,10 +92,12 @@ class Documentation(object):
         f.close()
 
     def remove(self, name):
-        del self.components[name]
+        if name in self.components.keys():#delete only if it exists
+            del self.components[name]
 
     def add(self, name, doc):
-        self.components[name]=doc
+        if doc:#do not create empty records
+            self.components[name]=doc
 
 
 


### PR DESCRIPTION
I made some changes to be able to move components properly without abandoning aliases documentation.

SchLib class nnow has 2 additional methods:
- addComponent( component_reference )
- removeComponent( component_name )
 - returns reference to removed component

Both methods handles symbol + documentation (incl. aliases).

This PR fixes #30 and #4 