### PR TITLE
Added the 'silent' option to checklib.py

### DIFF
--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -31,7 +31,7 @@ parser.add_argument('--fix', help='fix the violations if possible', action='stor
 parser.add_argument('--nocolor', help='does not use colors to show the output', action='store_true')
 parser.add_argument('--enable-extra', help='enable extra checking', action='store_true')
 parser.add_argument('-v', '--verbose', help='show status of all components and extra information about the violation', action='count')
-parser.add_argument('-s', '--silent', help='If the silent option is set, there will be no output displayed for components with zero violations. This option is useful for checking large libraries', action='count')
+parser.add_argument('-s', '--silent', help='skip output for symbols passing all checks', action='store_true')
 args = parser.parse_args()
 
 printer = PrintColor(use_color = not args.nocolor)

--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -31,6 +31,7 @@ parser.add_argument('--fix', help='fix the violations if possible', action='stor
 parser.add_argument('--nocolor', help='does not use colors to show the output', action='store_true')
 parser.add_argument('--enable-extra', help='enable extra checking', action='store_true')
 parser.add_argument('-v', '--verbose', help='show status of all components and extra information about the violation', action='count')
+parser.add_argument('-s', '--silent', help='If the silent option is set, there will be no output displayed for components with zero violations. This option is useful for checking large libraries', action='count')
 args = parser.parse_args()
 
 printer = PrintColor(use_color = not args.nocolor)
@@ -65,13 +66,17 @@ for libfile in libfiles:
         if args.component and args.component != component.name: continue
         n_components += 1
 
-        printer.green('checking component: %s' % component.name)
+        
 
         # check the rules
         n_violations = 0
         for rule in all_rules:
             rule = rule(component)
             if rule.check():
+            
+                if n_violations == 0: #this is the first violation
+                    printer.green('checking component: %s' % component.name)
+                    
                 n_violations += 1
                 printer.yellow('Violating ' +  rule.name, indentation=2)
                 if args.verbose:
@@ -87,6 +92,8 @@ for libfile in libfiles:
             for ec in all_ec:
                 ec = ec(component)
                 if ec.check():
+                    if n_violations == 0: #this is the first violation
+                        printer.green('checking component: %s' % component.name)
                     n_violations += 1
                     printer.yellow('Violating ' +  ec.name, indentation=2)
 
@@ -99,7 +106,8 @@ for libfile in libfiles:
                     processVerboseOutput(ec.messageBuffer)
 
         # check the number of violations
-        if n_violations == 0:
+        if n_violations == 0 and not args.silent:
+            printer.light_green('Component: {cmp}'.format(cmp=component.name))
             printer.light_green('No violations found', indentation=2)
 
     if args.fix:


### PR DESCRIPTION
This PR adds the -s / --silent flag to checklib.py

If set, the checklib.py script hides any output for components that do not have any KLC violations.

e.g. when checking a large library (or multiple libraries) it can be useful to only display the components that DID violate, rather than having many lines of "No violations found".

Then the -s option is not specified, action is default.