### PR TITLE
Added --silent option for check_kicad_mod.py

### DIFF
--- a/pcb/check_kicad_mod.py
+++ b/pcb/check_kicad_mod.py
@@ -59,6 +59,7 @@ for filename in files:
             rule.fix()
 
     if n_violations == 0 and not args.silent:
+        printer.green('checking module: {mod}'.format(mod = module.name))
         printer.light_green('No violations found', indentation=2)
     elif args.fix:
         module.save()

--- a/pcb/check_kicad_mod.py
+++ b/pcb/check_kicad_mod.py
@@ -19,6 +19,8 @@ parser.add_argument('kicad_mod_files', nargs='+')
 parser.add_argument('--fix', help='fix the violations if possible', action='store_true')
 parser.add_argument('--nocolor', help='does not use colors to show the output', action='store_true')
 parser.add_argument('-v', '--verbose', help='show status of all modules and extra information about the violation', action='store_true')
+parser.add_argument('-s', '--silent', help='skip output for symbols passing all checks', action='store_true')
+
 args = parser.parse_args()
 
 printer = PrintColor(use_color = not args.nocolor)
@@ -36,12 +38,14 @@ for f in args.kicad_mod_files:
         
 for filename in files:
     module = KicadMod(filename)
-    printer.green('checking module: %s' % module.name)
 
     n_violations = 0
     for rule in all_rules:
         rule = rule(module)
         if rule.check():
+            #this is the first violation
+            if n_violations == 0:
+                printer.green('checking module: %s' % module.name)
             n_violations += 1
             printer.yellow('Violating ' +  rule.name, indentation=2)
             if args.verbose:
@@ -54,7 +58,7 @@ for filename in files:
         if args.fix:
             rule.fix()
 
-    if n_violations == 0:
+    if n_violations == 0 and not args.silent:
         printer.light_green('No violations found', indentation=2)
     elif args.fix:
         module.save()


### PR DESCRIPTION
This PR adds the -s option to the kicad_mod checker, and hides output for modules that pass all checks (e.g. when checking an entire directory of footprints)