### PR TITLE
RFC: KLC 3.9

### DIFF
--- a/schlib/rules/__init__.py
+++ b/schlib/rules/__init__.py
@@ -1,2 +1,2 @@
 
-__all__ = ["rule3_1", "rule3_2", "rule3_6", "rule3_8", "EC01", "EC02", "EC03", "EC04"]
+__all__ = ["rule3_1", "rule3_2", "rule3_6", "rule3_8", "rule3_9", "EC01", "EC02", "EC03", "EC04"]

--- a/schlib/rules/__init__.py
+++ b/schlib/rules/__init__.py
@@ -1,2 +1,12 @@
 
-__all__ = ["rule3_1", "rule3_2", "rule3_6", "rule3_8", "rule3_9", "EC01", "EC02", "EC03", "EC04"]
+__all__ = [
+"rule3_1",
+"rule3_2",
+"rule3_6",
+"rule3_8", 
+"rule3_9", 
+"EC01", 
+"EC02", 
+"EC03", 
+"EC04"
+]

--- a/schlib/rules/rule3_9.py
+++ b/schlib/rules/rule3_9.py
@@ -40,7 +40,7 @@ class Rule(KLCRule):
                     self.verboseOut(Verbosity.HIGH, Severity.ERROR, fp_desc + "should be of the format Library:Footprint")
                     
                 # Footprint name cannot contain any illegal pathname characters
-                invalid = '\/*?:"<>|'
+                invalid = '\/*?"<>|'
                 if any([i in fp_name for i in invalid]):
                     fail = True
                     self.verboseOut(Verbosity.HIGH, Severity.ERROR, fp_desc + "contains illegal filename characters")

--- a/schlib/rules/rule3_9.py
+++ b/schlib/rules/rule3_9.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+from rules.rule import *
+
+class Rule(KLCRule):
+    """
+    Create the methods check and fix to use with the kicad lib files.
+    """
+    def __init__(self, component):
+        super(Rule, self).__init__(component, 'Rule 3.9', 'Default component footprint is appropriately set.')
+
+    def check(self):
+        """
+        Proceeds the checking of the rule.
+        """
+        
+        fail = False
+
+        #footprint field is index [2]
+        if len(self.component.fields) >= 3:
+            fp = self.component.fields[2]
+            fp_name = fp['name']
+            
+            #strip the quote characters
+            if fp_name.startswith('"') and fp_name.endswith('"'):
+                fp_name = fp_name[1:-1]
+            
+            fp_desc = "Footprint field '{fp}' ".format(fp=fp_name)
+            
+            #only check if there is text in the name
+            if len(fp_name) > 0:
+                #footprint field should be set to invisible (if it has any text in it)
+                if fp['visibility'] == 'V':
+                    fail = True
+                    self.verboseOut(Verbosity.HIGH, Severity.WARNING, fp_desc + "should be set to invisible.")
+                   
+                #footprint field should be of the format "Footprint_Library:Footprint_Name"
+                if fp_name.count(":") is not 1 or fp_name.startswith(":") or fp_name.endswith(":"):
+                    fail = True
+                    self.verboseOut(Verbosity.HIGH, Severity.ERROR, fp_desc + "should be of the format Library:Footprint")
+                    
+                #footprint name cannot contain any illegal pathname characters
+                invalid = '\/*?:"<>|'
+                if any([i in fp_name for i in invalid]):
+                    fail = True
+                    self.verboseOut(Verbosity.HIGH, Severity.ERROR, fp_desc + "contains illegal filename characters")
+            
+        return fail
+
+    def fix(self):
+        """
+        Proceeds the fixing of the rule, if possible.
+        """
+        self.verboseOut(Verbosity.NORMAL, Severity.INFO, "FIX: not supported" )

--- a/schlib/rules/rule3_9.py
+++ b/schlib/rules/rule3_9.py
@@ -7,7 +7,7 @@ class Rule(KLCRule):
     Create the methods check and fix to use with the kicad lib files.
     """
     def __init__(self, component):
-        super(Rule, self).__init__(component, 'Rule 3.9', 'Default component footprint is appropriately set.')
+        super(Rule, self).__init__(component, 'Rule 3.9', 'For components with a single default footprint, footprint field is filled with valid footprint filename')
 
     def check(self):
         """
@@ -16,30 +16,30 @@ class Rule(KLCRule):
         
         fail = False
 
-        #footprint field is index [2]
+        # Footprint field is index [2]
         if len(self.component.fields) >= 3:
             fp = self.component.fields[2]
             fp_name = fp['name']
             
-            #strip the quote characters
+            # Strip the quote characters
             if fp_name.startswith('"') and fp_name.endswith('"'):
                 fp_name = fp_name[1:-1]
             
             fp_desc = "Footprint field '{fp}' ".format(fp=fp_name)
             
-            #only check if there is text in the name
+            # Only check if there is text in the name
             if len(fp_name) > 0:
                 #footprint field should be set to invisible (if it has any text in it)
                 if fp['visibility'] == 'V':
                     fail = True
                     self.verboseOut(Verbosity.HIGH, Severity.WARNING, fp_desc + "should be set to invisible.")
                    
-                #footprint field should be of the format "Footprint_Library:Footprint_Name"
+                # Footprint field should be of the format "Footprint_Library:Footprint_Name"
                 if fp_name.count(":") is not 1 or fp_name.startswith(":") or fp_name.endswith(":"):
                     fail = True
                     self.verboseOut(Verbosity.HIGH, Severity.ERROR, fp_desc + "should be of the format Library:Footprint")
                     
-                #footprint name cannot contain any illegal pathname characters
+                # Footprint name cannot contain any illegal pathname characters
                 invalid = '\/*?:"<>|'
                 if any([i in fp_name for i in invalid]):
                     fail = True


### PR DESCRIPTION
In this PR I propose a new rule for KLC, 3.9, which checks the values of the default footprint for a component.

1. If the footprint field is empty, then the check passes (ignore any further tests)
2. Footprint field should be set to invisible
3. Footprint field should be of the format "Library:Footprint" (i.e. it must have a single ":" character)
4. Footprint field cannot have any illegal path-name characters e.g. \/*?:"<>| 

I think such a test (with a good description in the KLC rule file) complements the current set and will also help anyone wanting to submit parts.