### PR TITLE
.lib comparison

### DIFF
--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -78,7 +78,11 @@ exit_code = 0
 for libfile in libfiles:
     lib = SchLib(libfile)
     n_components = 0
-    printer.purple('library: %s' % libfile)
+    
+    # Print the library name if multiple libraries have been passed
+    if len(libfiles) > 1:
+        printer.purple('library: %s' % libfile)
+    
     for component in lib.components:
         # skip components with non matching names
         if args.component and args.component != component.name: continue

--- a/schlib/comparelibs.py
+++ b/schlib/comparelibs.py
@@ -23,11 +23,12 @@ parser.add_argument("--check", help="Perform KLC check on updated/added componen
 args = parser.parse_args()
 
 def KLCCheck(component):
-    call = "python checklib.py {lib} -c={cmp} --enable-extra -vv -s".format(
+    call = "python checklib.py {lib} -c={cmp} --enable-extra -s".format(
                 lib = args.new,
                 cmp = component
                 )
-    os.system(call)
+    
+    return os.system(call)
 
 printer = PrintColor()
 
@@ -48,6 +49,8 @@ for c in old_lib.components:
 deleted = []
 added = []
 updated = []
+
+errors = 0
     
 # First, see if any components have been deleted (in OLD but not in NEW)
 for name in old_chk.keys():
@@ -78,7 +81,8 @@ if len(updated) > 0:
 
         # perform KLC check on component
         if args.check:
-            KLCCheck(name)
+            if KLCCheck(name) is not 0:
+                errors += 1
             
 # Display any added components
 if len(added) > 0:
@@ -88,4 +92,8 @@ if len(added) > 0:
         
         # Perform KLC check on component
         if args.check:
-            KLCCheck(name)
+            if KLCCheck(name) is not 0:
+                errors += 1
+
+# Return the number of errors found ( zero if --check is not set )                
+sys.exit(errors)

--- a/schlib/comparelibs.py
+++ b/schlib/comparelibs.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+
+This file compares two .lib files and generates a list of deleted / added / updated components.
+This is to be used to compare an updated library file with a previous version to determine which components have been changed.
+
+"""
+
+import argparse
+import sys
+from schlib import *
+from print_color import *
+import os
+
+parser = argparse.ArgumentParser(description="Compare two .lib files to determine which symbols have changed")
+
+parser.add_argument("new", help="New (updated) .lib file")
+parser.add_argument("original", help="Original .lib file for comparison")
+parser.add_argument("--check", help="Perform KLC check on updated/added components", action='store_true')
+
+args = parser.parse_args()
+
+def KLCCheck(component):
+    call = "python checklib.py {lib} -c={cmp} --enable-extra -vv -s".format(
+                lib = args.new,
+                cmp = component
+                )
+    os.system(call)
+
+printer = PrintColor()
+
+new_lib = SchLib(args.new)
+old_lib = SchLib(args.original)
+
+# dicts of name:checksum pairs
+new_chk = {}
+old_chk = {}
+
+# Extract name and checksum information
+for c in new_lib.components:
+    new_chk[c.name] = c.checksum
+    
+for c in old_lib.components:
+    old_chk[c.name] = c.checksum
+    
+deleted = []
+added = []
+updated = []
+    
+# First, see if any components have been deleted (in OLD but not in NEW)
+for name in old_chk.keys():
+    if not name in new_chk:
+        deleted.append(name)
+        continue
+        
+    # Next, check if there are any component checksum differences
+    if not old_chk[name] == new_chk[name]:
+        updated.append(name)
+        
+# Lastly, see if any new components have been added
+for name in new_chk.keys():
+    if not name in old_chk:
+        added.append(name)
+        
+# Display any deleted components
+if len(deleted) > 0:
+    printer.light_red("Components Removed: {n}".format(n=len(deleted)))
+    for name in deleted:
+        printer.light_red(name)
+        
+# Display any updated components
+if len(updated) > 0:
+    printer.yellow("Components Updated: {n}".format(n=len(updated)))
+    for name in updated:
+        printer.yellow(name)
+
+        # perform KLC check on component
+        if args.check:
+            KLCCheck(name)
+            
+# Display any added components
+if len(added) > 0:
+    printer.light_green("Components Added: {n}".format(n=len(added)))
+    for name in added:
+        printer.light_green(name)
+        
+        # Perform KLC check on component
+        if args.check:
+            KLCCheck(name)

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -3,6 +3,7 @@
 import sys, shlex
 import os.path
 from collections import OrderedDict
+import hashlib
 
 class Documentation(object):
     """
@@ -128,7 +129,11 @@ class Component(object):
         building_fplist = False
         building_draw = False
         building_fields = False
+        
+        checksum_data = ''
+        
         for line in data:
+            checksum_data += line
             line = line.replace('\n', '')
             s = shlex.shlex(line)
             s.whitespace_split = True
@@ -211,7 +216,10 @@ class Component(object):
                         values = line[1:] + ['' for n in range(len(self._FN_KEYS) - len(line[1:]))]
                         self.fields.append(dict(zip(self._FN_KEYS,values)))
 
-
+        #perform checksum calculation
+        x = checksum_data.encode('utf-8')
+        md5 = hashlib.md5(x)
+        self.checksum = md5.hexdigest()
 
         # define some shortcuts
         self.name = self.definition['name']


### PR DESCRIPTION
This PR adds two key features:

**Component Checksum**
The schlib.py script now calculates component-level checksums. This can be used to determine which parts have been updated between different versions of the .lib file

**Library Comparison Script**
The *comparelibs.py* script takes two versions of a .lib file, and lists which components have been added / deleted / changed. If the --check flag is given, any updated/additional components are automagically run through the KLC script

(The -silent option for checklib.py has also been merged into this branch for argument pass-through)