### PR TITLE
Removed duplicate output

### DIFF
--- a/pcb/check_kicad_mod.py
+++ b/pcb/check_kicad_mod.py
@@ -45,7 +45,6 @@ for filename in files:
         printer.red('could not parse module: %s' % filename)
         exit_code += 1
         continue
-    printer.green('checking module: %s' % module.name)
 
     n_violations = 0
     for rule in all_rules:


### PR DESCRIPTION
This PR simply fixes an error in check_kicad_mod.py which printed each module name twice