### PR TITLE
Decode library text in schlib.py

### DIFF
--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -133,7 +133,7 @@ class Component(object):
         checksum_data = ''
         
         for line in data:
-            checksum_data += line
+            checksum_data += line.decode('utf-8')
             line = line.replace('\n', '')
             s = shlex.shlex(line)
             s.whitespace_split = True


### PR DESCRIPTION
This is to avoid problems with encoding non-ASCII characters.