### PR TITLE
(KLC 6.6) check if end of line is aligned on 0.01mm grid instead of 0.05mm

### DIFF
--- a/pcb/rules/rule6_6.py
+++ b/pcb/rules/rule6_6.py
@@ -54,7 +54,7 @@ class Rule(KLCRule):
             x, y = line['end']['x'], line['end']['y']
             x = int( (x + (0.0000001 if x >= 0 else -0.0000001))*1E6 )
             y = int( (y + (0.0000001 if y >= 0 else -0.0000001))*1E6 )
-            end_is_wrong = (x % 0.05E6) or (y % 0.05E6)
+            end_is_wrong = (x % 0.01E6) or (y % 0.01E6)
             nanometers['end'] = {'x':x, 'y':y}
 
             if start_is_wrong or end_is_wrong:


### PR DESCRIPTION
I noticed the the test checked if end of the lines of the courtyard were on a 0.05mm grid instead of 0.01mm (KLC 6.6).