### PR TITLE
Fixes for comparelibs.py

### DIFF
--- a/schlib/comparelibs.py
+++ b/schlib/comparelibs.py
@@ -37,11 +37,17 @@ if not args.old:
     ExitError("Original file not supplied")
 
 def KLCCheck(component):
-    call = "python checklib.py {lib} -c={cmp} --enable-extra -vv -s {nocolor}".format(
+    # Wrap library in "quotes" if required
+    lib = args.new
+    if " " in lib and '"' not in lib:
+        lib = '"' + lib + '"'
+
+    call = 'python checklib.py {lib} -c={cmp} --enable-extra -vv -s {nocolor}'.format(
                 lib = args.new,
                 cmp = component,
                 nocolor = "--nocolor" if args.nocolor else ""
                 )
+                
     return os.system(call)
 
 printer = PrintColor(use_color = not args.nocolor)
@@ -110,6 +116,9 @@ if len(updated) > 0:
         if args.check:
             if KLCCheck(cmp) is not 0:
                 errors += 1
+                
+if args.verbose and len(deleted) == 0 and len(added) == 0 and len(updated) == 0:
+    printer.green("No component variations found")
             
 # Return the number of errors found ( zero if --check is not set )                
 sys.exit(errors)

--- a/schlib/comparelibs.py
+++ b/schlib/comparelibs.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
 """
 
 This file compares two .lib files and generates a list of deleted / added / updated components.
@@ -13,37 +15,45 @@ import sys
 from schlib import *
 from print_color import *
 import os
-from glob import glob
+
+def ExitError( msg ):
+    print(msg)
+    sys.exit(-1)
 
 parser = argparse.ArgumentParser(description="Compare two .lib files to determine which symbols have changed")
 
 parser.add_argument("--new", help="New (updated) .lib file")
-parser.add_argument("--original", help="Original .lib file for comparison")
+parser.add_argument("--old", help="Old (original) .lib file for comparison")
 parser.add_argument("-v", "--verbose", help="Enable extra verbose output", action="store_true")
 parser.add_argument("--check", help="Perform KLC check on updated/added components", action='store_true')
 parser.add_argument("--nocolor", help="Does not use colors to show the output", action='store_true')
+
 args = parser.parse_args()
 
-def KLCCheck(component, library):
-    call = "python3 checklib.py {lib} -c='{cmp}' --enable-extra -s {nocolor}".format(
-                lib = library,
+if not args.new:
+    ExitError("New file not supplied")
+
+if not args.old:
+    ExitError("Original file not supplied")
+
+def KLCCheck(component):
+    call = "python checklib.py {lib} -c={cmp} --enable-extra -vv -s {nocolor}".format(
+                lib = args.new,
                 cmp = component,
                 nocolor = "--nocolor" if args.nocolor else ""
-                )
+                )    
+    print("Call:" , call)
     
     return os.system(call)
 
 printer = PrintColor(use_color = not args.nocolor)
 
+new_lib = SchLib( args.new )
+old_lib = SchLib( args.old )
 
-#grab list of libfiles (even on windows!)
-old_libs = []
-new_libs = []
-
-#for lib in args.new:
-new_libs += glob(args.new)
-
-old_libs += glob(args.original)
+# Dicts of name:checksum pairs
+new_chk = {}
+old_chk = {}
 
 deleted = []
 added = []
@@ -51,65 +61,56 @@ updated = []
 
 errors = 0
 
-for old_lib_path, new_lib_path in zip(old_libs, new_libs):
-    # dicts of name:checksum pairs
-    new_lib = SchLib(new_lib_path)
-    old_lib = SchLib(old_lib_path)
-
-    new_chk = {}
-    old_chk = {}
-
-    # Extract name and checksum information
-    for c in new_lib.components:
-        new_chk[c.name] = c.checksum
+for cmp in new_lib.components:
+    new_chk[cmp.name] = cmp.checksum
     
-    for c in old_lib.components:
-        old_chk[c.name] = c.checksum
+for cmp in old_lib.components:
+    old_chk[cmp.name] = cmp.checksum
     
-    # First, see if any components have been deleted (in OLD but not in NEW)
-    for name in old_chk.keys():
-        if not name in new_chk:
-            deleted.append({'name': name, 'library': old_lib_path})
-            continue
+for name in old_chk.keys():
+    # First, check if any components have been deleted
+    if not name in new_chk:
+        deleted.append(name)
+        continue
         
-        # Next, check if there are any component checksum differences
-        if not old_chk[name] == new_chk[name]:
-            updated.append({'name': name, 'library': new_lib_path})
+    # Next, check for checksum mismatch
+    if not old_chk[name] == new_chk[name]:
+        updated.append(name)
         
-    # Lastly, see if any new components have been added
-    for name in new_chk.keys():
-        if not name in old_chk:
-            added.append({'name': name, 'library': new_lib_path})
+# Finally, check for NEW components
+for name in new_chk.keys():
+    if not name in old_chk:
+        added.append(name)
 
 # Display any deleted components
 if len(deleted) > 0:
     if args.verbose:
         printer.light_red("Components Removed: {n}".format(n=len(deleted)))
-    for component in deleted:
-        printer.light_red("- " + component['name'])
+    for cmp in deleted:
+        printer.light_red("- " + cmp)
             
 # Display any added components
 if len(added) > 0:
     if args.verbose:
         printer.light_green("Components Added: {n}".format(n=len(added)))
-    for component in added:
-        printer.light_green("+ " + component['name'])
+    for cmp in added:
+        printer.light_green("+ " + cmp)
 
         # Perform KLC check on component
         if args.check:
-            if KLCCheck(component['name'], component['library']) is not 0:
+            if KLCCheck(cmp) is not 0:
                 errors += 1
                 
 # Display any updated components
 if len(updated) > 0:
     if args.verbose:
         printer.yellow("Components Updated: {n}".format(n=len(updated)))
-    for component in updated:
-        printer.yellow("# " + component['name'])
+    for cmp in updated:
+        printer.yellow("# " + cmp)
 
         # perform KLC check on component
         if args.check:
-            if KLCCheck(component['name'], component['library']) is not 0:
+            if KLCCheck(cmp) is not 0:
                 errors += 1
             
 # Return the number of errors found ( zero if --check is not set )                

--- a/schlib/comparelibs.py
+++ b/schlib/comparelibs.py
@@ -43,7 +43,7 @@ def KLCCheck(component):
         lib = '"' + lib + '"'
 
     call = 'python checklib.py {lib} -c={cmp} --enable-extra -vv -s {nocolor}'.format(
-                lib = args.new,
+                lib = lib,
                 cmp = component,
                 nocolor = "--nocolor" if args.nocolor else ""
                 )

--- a/schlib/comparelibs.py
+++ b/schlib/comparelibs.py
@@ -41,9 +41,7 @@ def KLCCheck(component):
                 lib = args.new,
                 cmp = component,
                 nocolor = "--nocolor" if args.nocolor else ""
-                )    
-    print("Call:" , call)
-    
+                )
     return os.system(call)
 
 printer = PrintColor(use_color = not args.nocolor)

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -34,7 +34,7 @@ class Documentation(object):
 
         else:
             if not os.path.isfile(self.filename):
-                sys.stderr.write("Not a file\n")
+                sys.stderr.write('"{filename}" is not a valid .dcm file\n'.format(filename=self.filename))
                 return
             else:
                 self.validFile = True
@@ -291,7 +291,7 @@ class SchLib(object):
 
         else:
             if not os.path.isfile(self.filename):
-                sys.stderr.write("Not a file\n")
+                sys.stderr.write('"{filename}" is not a valid .lib file\n'.format(filename=self.filename))
                 return
             else:
                 self.validFile = True


### PR DESCRIPTION
(Also added extra verbose error messages for schlib.py)

The updates made in https://github.com/KiCad/kicad-library-utils/pull/52 have actually caused some errors as indicated here: https://github.com/KiCad/kicad-library-utils/issues/70

This PR fixes those errors and also reverts the script to the previous mode where it only runs on a single .lib file at a time. 

Running the script on an entire batch of lib files should be handled by a separate wrapper script.