### PR TITLE
fixes/improvements to rules 6.3, 6.6 and 10.3 + commandline-options --addsilkscreenrect and --rotate

### DIFF
--- a/pcb/check_kicad_mod.py
+++ b/pcb/check_kicad_mod.py
@@ -70,8 +70,8 @@ for filename in files:
 
                 # example of customized printing feedback by checking the rule name
                 # and a specific variable of the rule
-                if rule.name == 'Rule 6.6' and len(rule.f_courtyard_all) == 0:
-                    printer.red('No courtyard line found in the module', indentation=4)
+                #if rule.name == 'Rule 6.6' and len(rule.f_courtyard_all) == 0:
+                #    printer.red('No courtyard line found in the module', indentation=4)
         if args.fix:
             rule.fix()
 

--- a/pcb/kicad_mod.py
+++ b/pcb/kicad_mod.py
@@ -3,6 +3,18 @@
 
 import sexpr, re, math
 
+def _rotatePoint(x, degrees):
+	xx=x        
+	y={'x':x['x'], 'y':x['y']}
+	y['x']=math.cos(degrees/180.0*math.pi)*xx['x']+math.sin(degrees/180.0*math.pi)*xx['y'];
+	y['y']=-math.sin(degrees/180.0*math.pi)*xx['x']+math.cos(degrees/180.0*math.pi)*xx['y'];
+	if 'orientation' in x:
+		y['orientation']=xx['orientation']-degrees               
+	if 'z' in x:
+		y['z']=xx['z']
+	#print('before rotation (degrees=', degrees, ') x=', xx, '    after rotation y=', y)
+	return y
+
 class KicadMod(object):
     """
     A class to parse kicad_mod files format of the KiCad
@@ -540,6 +552,44 @@ class KicadMod(object):
         for model in self.models:
             model['pos']['x'] -= anchor_point[0]/25.4
             model['pos']['y'] += anchor_point[1]/25.4
+            
+    
+        
+    def rotateFootprint(self, degrees):
+        # change reference position
+        self.reference['pos']=_rotatePoint(self.reference['pos'], degrees)
+
+        # change value position
+        self.value['pos']=_rotatePoint(self.value['pos'], degrees)
+
+        # change user text position
+        for text in self.userText:
+            text['pos']=_rotatePoint(text['pos'], degrees)
+            
+
+        # change lines position
+        for line in self.lines:
+            line['start']=_rotatePoint(line['start'], degrees)
+            line['end']=_rotatePoint(line['end'], degrees)
+
+        # change circles position
+        for circle in self.circles:
+            circle['center']=_rotatePoint(circle['center'], degrees)
+            circle['end']=_rotatePoint(circle['end'], degrees)
+
+        # change arcs position
+        for arc in self.arcs:
+            arc['start']=_rotatePoint(arc['start'], degrees)
+            arc['end']=_rotatePoint(arc['end'], degrees)
+
+        # change pads positions
+        for pad in self.pads:
+            pad['pos']=_rotatePoint(pad['pos'], degrees)
+            
+        # change models
+        for model in self.models:
+            model['pos']=_rotatePoint(model['pos'], -degrees)
+            model['rotate']['z']=model['rotate']['z']-degrees
 
     def filterLines(self, layer):
         lines = []

--- a/pcb/kicad_mod.py
+++ b/pcb/kicad_mod.py
@@ -25,7 +25,6 @@ class KicadMod(object):
         # check file line-endings
         self.unix_line_endings=True
         filecontentsraw=open(filename,"rb").readline()
-        print(filecontentsraw)
         if (filecontentsraw[-2]==0x0D and filecontentsraw[-1]==0x0A) or (filecontentsraw[-1]==0x0D):
             self.unix_line_endings=False
 

--- a/pcb/kicad_mod.py
+++ b/pcb/kicad_mod.py
@@ -805,7 +805,7 @@ class KicadMod(object):
         # convert array data to s-expression and save in the disc
         output = sexpr.build_sexp(self.sexpr_data)
         output = sexpr.format_sexp(output, max_nesting=1)
-        f = open(filename, 'w')
+        f = open(filename, 'w', newline='\n')
         f.write(output)
         f.close()
 

--- a/pcb/kicad_mod.py
+++ b/pcb/kicad_mod.py
@@ -4,16 +4,16 @@
 import sexpr, re, math
 
 def _rotatePoint(x, degrees):
-	xx=x        
-	y={'x':x['x'], 'y':x['y']}
-	y['x']=math.cos(degrees/180.0*math.pi)*xx['x']+math.sin(degrees/180.0*math.pi)*xx['y'];
-	y['y']=-math.sin(degrees/180.0*math.pi)*xx['x']+math.cos(degrees/180.0*math.pi)*xx['y'];
-	if 'orientation' in x:
-		y['orientation']=xx['orientation']-degrees               
-	if 'z' in x:
-		y['z']=xx['z']
-	#print('before rotation (degrees=', degrees, ') x=', xx, '    after rotation y=', y)
-	return y
+    xx=x        
+    y={'x':x['x'], 'y':x['y']}
+    y['x']=math.cos(degrees/180.0*math.pi)*xx['x']+math.sin(degrees/180.0*math.pi)*xx['y'];
+    y['y']=-math.sin(degrees/180.0*math.pi)*xx['x']+math.cos(degrees/180.0*math.pi)*xx['y'];
+    if 'orientation' in x:
+        y['orientation']=xx['orientation']-degrees               
+    if 'z' in x:
+        y['z']=xx['z']
+    #print('before rotation (degrees=', degrees, ') x=', xx, '    after rotation y=', y)
+    return y
 
 class KicadMod(object):
     """
@@ -21,6 +21,13 @@ class KicadMod(object):
     """
     def __init__(self, filename):
         self.filename = filename
+        
+        # check file line-endings
+        self.unix_line_endings=True
+        filecontentsraw=open(filename,"rb").readline()
+        print(filecontentsraw)
+        if (filecontentsraw[-2]==0x0D and filecontentsraw[-1]==0x0A) or (filecontentsraw[-1]==0x0D):
+            self.unix_line_endings=False
 
         # read the s-expression data
         f = open(filename)
@@ -805,7 +812,7 @@ class KicadMod(object):
         # convert array data to s-expression and save in the disc
         output = sexpr.build_sexp(self.sexpr_data)
         output = sexpr.format_sexp(output, max_nesting=1)
-        f = open(filename, 'w', newline='\n')
+        f = open(filename, 'w', newline='')
         f.write(output)
         f.close()
 

--- a/pcb/kicad_mod.py
+++ b/pcb/kicad_mod.py
@@ -535,6 +535,11 @@ class KicadMod(object):
         for pad in self.pads:
             pad['pos']['x'] -= anchor_point[0]
             pad['pos']['y'] -= anchor_point[1]
+            
+        # change models
+        for model in self.models:
+            model['pos']['x'] -= anchor_point[0]/25.4
+            model['pos']['y'] += anchor_point[1]/25.4
 
     def filterLines(self, layer):
         lines = []

--- a/pcb/rules/__init__.py
+++ b/pcb/rules/__init__.py
@@ -1,3 +1,3 @@
 
-__all__ = ["rule6_3", "rule6_4", "rule6_5", "rule6_6", "rule6_9",
+__all__ = ["rule1_8", "rule6_3", "rule6_4", "rule6_5", "rule6_6", "rule6_9",
            "rule10_1", "rule10_2", "rule10_3", "rule10_4", "rule10_5", "rule10_6", "rule10_7", "rule10_8"]

--- a/pcb/rules/rule.py
+++ b/pcb/rules/rule.py
@@ -4,11 +4,13 @@ class KLCRule(object):
     """
     A base class to represent a KLC rule
     """
-    def __init__(self, module, name, description,verbose_message=''):
+    def __init__(self, module, args, name, description,verbose_message='',fix_verbose_message=''):
         self.module = module
         self.name = name
         self.description = description
         self.verbose_message=verbose_message
+        self.fix_verbose_message=fix_verbose_message
+        self.args=args
 
     def check(self, module):
         raise NotImplementedError('The check method must be implemented')

--- a/pcb/rules/rule10_1.py
+++ b/pcb/rules/rule10_1.py
@@ -7,8 +7,8 @@ class Rule(KLCRule):
     """
     Create the methods check and fix to use with the kicad_mod files.
     """
-    def __init__(self, module):
-        super(Rule, self).__init__(module, 'Rule 10.1', 'Footprint name must match its filename. (.kicad_mod files).')
+    def __init__(self, module, args):
+        super(Rule, self).__init__(module, args, 'Rule 10.1', 'Footprint name must match its filename. (.kicad_mod files).')
 
     def check(self):
         """

--- a/pcb/rules/rule10_2.py
+++ b/pcb/rules/rule10_2.py
@@ -6,8 +6,8 @@ class Rule(KLCRule):
     """
     Create the methods check and fix to use with the kicad_mod files.
     """
-    def __init__(self, module):
-        super(Rule, self).__init__(module, 'Rule 10.2', 'Doc property contains a full description of footprint.')
+    def __init__(self, module, args):
+        super(Rule, self).__init__(module, args, 'Rule 10.2', 'Doc property contains a full description of footprint.')
 
     def check(self):
         """

--- a/pcb/rules/rule10_3.py
+++ b/pcb/rules/rule10_3.py
@@ -6,8 +6,8 @@ class Rule(KLCRule):
     """
     Create the methods check and fix to use with the kicad_mod files.
     """
-    def __init__(self, module):
-        super(Rule, self).__init__(module, 'Rule 10.3', 'Keywords are separated by spaces.')
+    def __init__(self, module, args):
+        super(Rule, self).__init__(module, args, 'Rule 10.3', 'Keywords are separated by spaces.')
 
     def check(self):
         """

--- a/pcb/rules/rule10_3.py
+++ b/pcb/rules/rule10_3.py
@@ -15,7 +15,10 @@ class Rule(KLCRule):
         """
         module = self.module
         if module.tags and module.tags.count(',') > 0:
-            self.verbose_message=self.verbose_message+"Tags ('{0}') contains commas!\n".format(module.tags)
+            self.verbose_message=self.verbose_message+"Tags ('{0}') contains commas ','!\n".format(module.tags)
+            return True
+        if module.tags and module.tags.count(';') > 0:
+            self.verbose_message=self.verbose_message+"Tags ('{0}') contains ';'!\n".format(module.tags)
             return True
         return False
 
@@ -25,4 +28,10 @@ class Rule(KLCRule):
         """
         module = self.module
         if self.check():
-            module.tags = ' '.join(module.tags.replace(' ', '').split(','))
+            tagsc=module.tags.split(',')
+            tags=[]
+            for t in tagsc:
+                tags=tags+t.split(';')
+            for i in range(0, len(tags)):
+                tags[i]=tags[i].strip()
+            module.tags = ' '.join(tags)

--- a/pcb/rules/rule10_4.py
+++ b/pcb/rules/rule10_4.py
@@ -6,10 +6,10 @@ class Rule(KLCRule):
     """
     Create the methods check and fix to use with the kicad_mod files.
     """
-    def __init__(self, module):
+    def __init__(self, module, args):
         self.expected_val_width=1
         self.expected_val_thickness=0.15
-        super(Rule, self).__init__(module, 'Rule 10.4', "Value has a height of {0}mm, thickness of {1}mm, is filled with footprint name and is placed on the fabrication layer.".format(self.expected_val_width,self.expected_val_thickness))
+        super(Rule, self).__init__(module, args, 'Rule 10.4', "Value has a height of {0}mm, thickness of {1}mm, is filled with footprint name and is placed on the fabrication layer.".format(self.expected_val_width,self.expected_val_thickness))
 
     def check(self):
         """

--- a/pcb/rules/rule10_5.py
+++ b/pcb/rules/rule10_5.py
@@ -9,7 +9,7 @@ class Rule(KLCRule):
     def __init__(self, module):
         self.expected_ref_thickness=0.15
         self.expected_ref_width=1
-        super(Rule, self).__init__(module, 'Rule 10.5', "Reference designator has a height of {0}mm or smaller if needed, thickness of {1}mm and is placed on the silkscreen layer.".format(self.expected_ref_width,self.expected_ref_thickness))
+        super(Rule, self).__init__(module, 'Rule 10.5', "Reference designator has a height of {0}mm or smaller if needed, thickness of {1}mm and is placed on the silkscreen and the fabrication layer.".format(self.expected_ref_width,self.expected_ref_thickness))
 
     def check(self):
         """
@@ -17,7 +17,41 @@ class Rule(KLCRule):
         """
         module = self.module
         ok=False
-
+        
+        needs_secondrefdes=True
+        secondrefdeslayer='F.Fab'
+        secondrefdespos=module.reference['pos']
+        secondrefdesfont=module.reference['font']
+        secondrefdestext='%R'
+        secondrefdes=[]
+        if module.reference['layer'] == 'B.SilkS':
+            secondrefdeslayer='B.Fab';
+        elif module.reference['layer'] == 'F.Fab':
+            secondrefdeslayer='F.SilkS';
+        elif module.reference['layer'] == 'B.Fab':
+            secondrefdeslayer='B.SilkS'
+        
+        for txt in module.userText:
+            if txt['user']=='%R' and txt['layer']==secondrefdeslayer:
+                needs_secondrefdes=False
+                secondrefdes=txt
+                secondrefdespos=txt['pos']
+                secondrefdeslayer=txt['layer']
+                secondrefdestext=txt['user']
+            if txt['user']=='%R' and txt['layer']!=secondrefdeslayer:
+                needs_secondrefdes=False
+                self.verbose_message=self.verbose_message+"Found user-text reference label (text='%R') on layer '{0}', but expected it on layer '{1}'!\n".format(txt['layer'], secondrefdeslayer)
+                secondrefdes=txt
+                secondrefdespos=txt['pos']
+                secondrefdeslayer=txt['layer']
+                secondrefdestext=txt['user']
+                ok=False
+        secondrefdesfont={'width': self.expected_ref_width, 'height': self.expected_ref_width, 'thickness': self.expected_ref_thickness, 'italic': False}
+        module.secondrefdespos=secondrefdespos
+        module.secondrefdesfont=secondrefdesfont
+        module.secondrefdeslayer=secondrefdeslayer
+        module.needs_secondrefdes=needs_secondrefdes
+                
         if module.reference['layer'] != 'F.SilkS' and module.reference['layer'] != 'B.SilkS':
             self.verbose_message=self.verbose_message+"Reference label is on layer '{0}', but should be on layer F.SilkS or B.SilkS!\n".format(module.reference['layer'])
             ok=True
@@ -33,6 +67,20 @@ class Rule(KLCRule):
         if (module.reference['font']['thickness'] != self.expected_ref_thickness):
             self.verbose_message=self.verbose_message+"Reference label has a thickness of {1}mm (expected: {0}mm).\n".format(self.expected_ref_thickness,module.reference['font']['thickness'])
             ok= True
+        if needs_secondrefdes:
+            self.verbose_message=self.verbose_message+"Reference label should also be available on layer '{0}'.\n".format(secondrefdeslayer)
+            ok= True
+        if len(secondrefdes)>0:
+            if (secondrefdes['font']['height'] > self.expected_ref_width):
+                self.verbose_message=self.verbose_message+"User-text reference label (text='%R') has a height of {1}mm (expected: <={0}mm).\n".format(self.expected_ref_width,secondrefdes['font']['height'])
+                ok= True
+            if (secondrefdes['font']['width'] > self.expected_ref_width):
+                self.verbose_message=self.verbose_message+"User-text reference label (text='%R') has a width of {1}mm (expected: <={0}mm).\n".format(self.expected_ref_width,secondrefdes['font']['width'])
+                ok= True
+            if (secondrefdes['font']['thickness'] != self.expected_ref_thickness):
+                self.verbose_message=self.verbose_message+"User-text reference label (text='%R') has a thickness of {1}mm (expected: {0}mm).\n".format(self.expected_ref_thickness,secondrefdes['font']['thickness'])
+                ok= True
+        
         return ok
         
 
@@ -47,3 +95,20 @@ class Rule(KLCRule):
             module.reference['font']['width'] = self.expected_ref_width
             module.reference['font']['height'] = self.expected_ref_width
             module.reference['font']['thickness'] = self.expected_ref_thickness
+            
+            if module.needs_secondrefdes:
+                txt={'user': '%R', 'pos': module.secondrefdespos, 'layer': module.secondrefdeslayer, 'font': module.secondrefdesfont, 'hide': False } 
+                module.userText.append(txt)
+                print('added second REFDES')
+            else:
+                for txt in range(0,len(module.userText)):
+                    if module.userText[txt]['user']=='%R':
+                        print('OLD: ', module.userText[txt])
+                        module.userText[txt]['pos']=module.secondrefdespos
+                        module.userText[txt]['layer']=module.secondrefdeslayer
+                        module.userText[txt]['font']=module.secondrefdesfont
+                        print('NEW: ', module.userText[txt])
+                        print('fixed second REFDES ', txt)
+                        break
+                        
+                        

--- a/pcb/rules/rule10_5.py
+++ b/pcb/rules/rule10_5.py
@@ -6,10 +6,10 @@ class Rule(KLCRule):
     """
     Create the methods check and fix to use with the kicad_mod files.
     """
-    def __init__(self, module):
+    def __init__(self, module, args):
         self.expected_ref_thickness=0.15
         self.expected_ref_width=1
-        super(Rule, self).__init__(module, 'Rule 10.5', "Reference designator has a height of {0}mm or smaller if needed, thickness of {1}mm and is placed on the silkscreen and the fabrication layer.".format(self.expected_ref_width,self.expected_ref_thickness))
+        super(Rule, self).__init__(module, args, 'Rule 10.5', "Reference designator has a height of {0}mm or smaller if needed, thickness of {1}mm and is placed on the silkscreen and the fabrication layer.".format(self.expected_ref_width,self.expected_ref_thickness))
 
     def check(self):
         """

--- a/pcb/rules/rule10_6.py
+++ b/pcb/rules/rule10_6.py
@@ -6,8 +6,8 @@ class Rule(KLCRule):
     """
     Create the methods check and fix to use with the kicad_mod files.
     """
-    def __init__(self, module):
-        super(Rule, self).__init__(module, 'Rule 10.6', 'Attributes is set to the appropriate value, see tooltip for more information.')
+    def __init__(self, module, args):
+        super(Rule, self).__init__(module, args, 'Rule 10.6', 'Attributes is set to the appropriate value, see tooltip for more information.')
 
     def check(self):
         """

--- a/pcb/rules/rule10_7.py
+++ b/pcb/rules/rule10_7.py
@@ -6,8 +6,8 @@ class Rule(KLCRule):
     """
     Create the methods check and fix to use with the kicad_mod files.
     """
-    def __init__(self, module):
-        super(Rule, self).__init__(module, 'Rule 10.7', 'All other properties are left to default values. (Move and Place: Free; Auto Place: 0 and 0,  Local Clearance Values: 0)')
+    def __init__(self, module, args):
+        super(Rule, self).__init__(module, args, 'Rule 10.7', 'All other properties are left to default values. (Move and Place: Free; Auto Place: 0 and 0,  Local Clearance Values: 0)')
 
     def check(self):
         """

--- a/pcb/rules/rule10_8.py
+++ b/pcb/rules/rule10_8.py
@@ -7,8 +7,8 @@ class Rule(KLCRule):
     """
     Create the methods check and fix to use with the kicad_mod files.
     """
-    def __init__(self, module):
-        super(Rule, self).__init__(module, 'Rule 10.8', '3D Shape ".wrl" files are named the same as their footprint and are placed in a folder named the same as the footprint library replacing the ".pretty" with ".3dshapes".')
+    def __init__(self, module, args):
+        super(Rule, self).__init__(module, args, 'Rule 10.8', '3D Shape ".wrl" files are named the same as their footprint and are placed in a folder named the same as the footprint library replacing the ".pretty" with ".3dshapes".')
 
     def check(self):
         """

--- a/pcb/rules/rule1_8.py
+++ b/pcb/rules/rule1_8.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division
+
+# math and comments from Michal script
+# https://github.com/michal777/KiCad_Lib_Check
+
+from rules.rule import *
+import re, os, math
+
+class Rule(KLCRule):
+    """
+    Create the methods check and fix to use with the kicad_mod files.
+    """
+    def __init__(self, module):
+        self.expected_width=0.05
+        self.expected_grid=0.01
+        super(Rule, self).__init__(module, 'Rule 1.8', "Library- and footprint-files use UNIX-sytle line-endings (i.e. \\n = LF = 0x0A).")
+        
+    def check(self):
+        """
+        Proceeds the checking of the rule.
+        """
+        module = self.module
+        
+        return not module.unix_line_endings
+
+    def fix(self):
+        """
+        Proceeds the fixing of the rule, if possible.
+        """
+
+                    

--- a/pcb/rules/rule1_8.py
+++ b/pcb/rules/rule1_8.py
@@ -15,7 +15,7 @@ class Rule(KLCRule):
     def __init__(self, module):
         self.expected_width=0.05
         self.expected_grid=0.01
-        super(Rule, self).__init__(module, 'Rule 1.8', "Library- and footprint-files use UNIX-sytle line-endings (i.e. \\n = LF = 0x0A).")
+        super(Rule, self).__init__(module, 'Rule 1.8', "Library files should use UNIX-style line-endings (LF)")
         
     def check(self):
         """

--- a/pcb/rules/rule1_8.py
+++ b/pcb/rules/rule1_8.py
@@ -12,10 +12,10 @@ class Rule(KLCRule):
     """
     Create the methods check and fix to use with the kicad_mod files.
     """
-    def __init__(self, module):
+    def __init__(self, module,args):
         self.expected_width=0.05
         self.expected_grid=0.01
-        super(Rule, self).__init__(module, 'Rule 1.8', "Library files should use UNIX-style line-endings (LF)")
+        super(Rule, self).__init__(module, args, 'Rule 1.8', "Library files should use UNIX-style line-endings (LF)",'')
         
     def check(self):
         """

--- a/pcb/rules/rule6_3.py
+++ b/pcb/rules/rule6_3.py
@@ -6,8 +6,8 @@ class Rule(KLCRule):
     """
     Create the methods check and fix to use with the kicad_mod files.
     """
-    def __init__(self, module):
-        super(Rule, self).__init__(module, 'Rule 6.3', 'For through-hole components, footprint anchor is set on pad 1.')
+    def __init__(self, module, args):
+        super(Rule, self).__init__(module, args, 'Rule 6.3', 'For through-hole components, footprint anchor is set on pad 1.')
 
     def check(self):
         """

--- a/pcb/rules/rule6_3.py
+++ b/pcb/rules/rule6_3.py
@@ -20,6 +20,8 @@ class Rule(KLCRule):
         # check if module is through-hole
         if module.attribute == 'pth':
             pads = module.getPadsByNumber(1)
+            if len(pads)==0:
+                pads = module.getPadsByNumber('A1')
             self.pin1_count = len(pads)
             self.pin1_position = []
 
@@ -42,5 +44,5 @@ class Rule(KLCRule):
         Proceeds the fixing of the rule, if possible.
         """
         module = self.module
-        if self.check():
+        if self.check() and len(self.pin1_position)>0:
             module.setAnchor(min(self.pin1_position))

--- a/pcb/rules/rule6_4.py
+++ b/pcb/rules/rule6_4.py
@@ -8,8 +8,8 @@ class Rule(KLCRule):
     """
     Create the methods check and fix to use with the kicad_mod files.
     """
-    def __init__(self, module):
-        super(Rule, self).__init__(module, 'Rule 6.4', 'For surface-mount devices, footprint anchor is placed in the middle with respect to device lead ends. (IPC-7351).')
+    def __init__(self, module, args):
+        super(Rule, self).__init__(module, args, 'Rule 6.4', 'For surface-mount devices, footprint anchor is placed in the middle with respect to device lead ends. (IPC-7351).')
 
     def check(self):
         """

--- a/pcb/rules/rule6_5.py
+++ b/pcb/rules/rule6_5.py
@@ -9,9 +9,9 @@ class Rule(KLCRule):
     """
     Create the methods check and fix to use with the kicad_mod files.
     """
-    def __init__(self, module):
+    def __init__(self, module, args):
         self.expected_width=0.12
-        super(Rule, self).__init__(module, 'Rule 6.5', "Silkscreen is not superposed to pads, its outline is completely visible after board assembly, uses {0}mm line width and provides a reference mark for pin 1. (IPC-7351C).".format(self.expected_width))
+        super(Rule, self).__init__(module, args, 'Rule 6.5', "Silkscreen is not superposed to pads, its outline is completely visible after board assembly, uses {0}mm line width and provides a reference mark for pin 1. (IPC-7351C).".format(self.expected_width))
 
     def check(self):
         """

--- a/pcb/rules/rule6_6.py
+++ b/pcb/rules/rule6_6.py
@@ -93,4 +93,37 @@ class Rule(KLCRule):
                 x, y = round(x / self.expected_grid*1E6) * self.expected_grid, round(y / self.expected_grid*1E6) * self.expected_grid
                 item['nanometers']['end']['x'], item['nanometers']['end']['y'] = x, y
 
-            # TODO: create courtyard if does not exists
+            # create courtyard if does not exists
+            if len(self.f_courtyard_all)+len(self.b_courtyard_all) == 0:
+                overpadBounds=module.overpadsBounds()
+                geoBounds=module.geometricBounds('F.Fab')
+                #print('overpadBounds=',overpadBounds)
+                #print('F.Fab: geoBounds=',geoBounds)
+                b={'lower':{'x':1.0E99, 'y':1.0E99},'higher':{'x':-1.0E99, 'y':-1.0E99}}
+                if (geoBounds['lower']['x']>1.0E98 and geoBounds['lower']['x']==geoBounds['lower']['y']) or (geoBounds['higher']['x']<-1.0e98 and geoBounds['higher']['x']==geoBounds['higher']['y']):
+                    geoBounds=module.geometricBounds('B.Fab')               
+                    #print('B.Fab: geoBounds=',geoBounds)
+                if (geoBounds['lower']['x']>1.0E98 and geoBounds['lower']['x']==geoBounds['lower']['y']) or (geoBounds['higher']['x']<-1.0e98 and geoBounds['higher']['x']==geoBounds['higher']['y']):
+                    geoBounds=module.geometricBounds('F.SilkS')
+                    #print('F.SilkS: geoBounds=',geoBounds)
+                if (geoBounds['lower']['x']>1.0E98 and geoBounds['lower']['x']==geoBounds['lower']['y']) or (geoBounds['higher']['x']<-1.0e98 and geoBounds['higher']['x']==geoBounds['higher']['y']):
+                    geoBounds=module.geometricBounds('B.SilkS')
+                    #print('B.SilkS: geoBounds=',geoBounds)
+                
+                b['lower']['x']=min(b['lower']['x'],overpadBounds['lower']['x'])
+                b['lower']['y']=min(b['lower']['y'],overpadBounds['lower']['y'])
+                b['higher']['x']=max(b['higher']['x'],overpadBounds['higher']['x'])
+                b['higher']['y']=max(b['higher']['y'],overpadBounds['higher']['y'])
+                b['lower']['x']=min(b['lower']['x'],geoBounds['lower']['x'])
+                b['lower']['y']=min(b['lower']['y'],geoBounds['lower']['y'])
+                b['higher']['x']=max(b['higher']['x'],geoBounds['higher']['x'])
+                b['higher']['y']=max(b['higher']['y'],geoBounds['higher']['y'])
+                
+                #print('b=',b)
+                if b['higher']['x']!=b['lower']['x'] and b['higher']['y']!=b['lower']['y'] and b['higher']['x']>-1.0E99 and b['higher']['y']>-1.0E99 and b['lower']['x']<1.0E99 and b['lower']['x']<1.0E99:
+                    #print('ADDING Courtyard-RECTANGLE')
+                    crt_offset=0.25
+                    module.addRectangle([b['lower']['x']-crt_offset, b['lower']['y']-crt_offset], [b['higher']['x']+crt_offset, b['higher']['y']+crt_offset], 'F.CrtYd', 0.05)
+                    
+                    
+                    

--- a/pcb/rules/rule6_6.py
+++ b/pcb/rules/rule6_6.py
@@ -169,7 +169,8 @@ class Rule(KLCRule):
         self.expected_crt_rectangle=self._calcCourtyardRectangle()
         
         if self.actual_crt_rectangle['width']*self.actual_crt_rectangle['width']>0 and self.expected_crt_rectangle['width']*self.expected_crt_rectangle['width']>0:
-            if math.fabs(self.actual_crt_rectangle['x']-self.expected_crt_rectangle['x'])>1e-5 or math.fabs(self.actual_crt_rectangle['y']-self.expected_crt_rectangle['y'])>1e-5 or math.fabs(self.actual_crt_rectangle['width']-self.expected_crt_rectangle['width'])>1e-5 or math.fabs(self.actual_crt_rectangle['height']-self.expected_crt_rectangle['height'])>1e-5:
+            crterrorbound=2e-2
+            if math.fabs(self.actual_crt_rectangle['x']-self.expected_crt_rectangle['x'])>crterrorbound or math.fabs(self.actual_crt_rectangle['y']-self.expected_crt_rectangle['y'])>crterrorbound or math.fabs(self.actual_crt_rectangle['width']-self.expected_crt_rectangle['width'])>crterrorbound or math.fabs(self.actual_crt_rectangle['height']-self.expected_crt_rectangle['height'])>crterrorbound:
                 self.verbose_message=self.verbose_message+"For this footprint a rectangular courtyard {0} was expected, but a courtyard rectangle {1} was found\n".format(self.expected_crt_rectangle,self.actual_crt_rectangle)
                 Ok=True
 

--- a/pcb/rules/rule6_6.py
+++ b/pcb/rules/rule6_6.py
@@ -6,6 +6,7 @@ from __future__ import division
 # https://github.com/michal777/KiCad_Lib_Check
 
 from rules.rule import *
+import re, os
 
 class Rule(KLCRule):
     """
@@ -121,8 +122,14 @@ class Rule(KLCRule):
                 
                 #print('b=',b)
                 if b['higher']['x']!=b['lower']['x'] and b['higher']['y']!=b['lower']['y'] and b['higher']['x']>-1.0E99 and b['higher']['y']>-1.0E99 and b['lower']['x']<1.0E99 and b['lower']['x']<1.0E99:
-                    #print('ADDING Courtyard-RECTANGLE')
+                    module_dir = os.path.split(os.path.dirname(os.path.realpath(module.filename)))[-1]
+                    self.module_dir = os.path.splitext(module_dir)
                     crt_offset=0.25
+                    if re.match("BGA\-.*", module.name) or re.match(".*Housing.*BGA.*", self.module_dir):
+                        crt_offset=1
+                    elif re.match(".*Connector.*", module.name) or re.match(".*Connector.*", self.module_dir) or re.match(".*Socket.*", module.name) or re.match(".*Socket.*", self.module_dir):
+                        crt_offset=0.5
+                    print("ADDING Courtyard-RECTANGLE with clearance {0}mm".format(crt_offset))
                     module.addRectangle([b['lower']['x']-crt_offset, b['lower']['y']-crt_offset], [b['higher']['x']+crt_offset, b['higher']['y']+crt_offset], 'F.CrtYd', 0.05)
                     
                     

--- a/pcb/rules/rule6_6.py
+++ b/pcb/rules/rule6_6.py
@@ -123,10 +123,11 @@ class Rule(KLCRule):
         b=self._getComponentAndPadBounds()
         if b['higher']['x']!=b['lower']['x'] and b['higher']['y']!=b['lower']['y'] and b['higher']['x']>-1.0E99 and b['higher']['y']>-1.0E99 and b['lower']['x']<1.0E99 and b['lower']['x']<1.0E99:
             crt_offset=self._calcCourtyardOffset()
-            return { 'x': int((b['lower']['x']-crt_offset)*100)/100, 
-                    'y':int((b['lower']['y']-crt_offset)*100)/100, 
-                    'width':int((math.fabs(b['higher']['x']-b['lower']['x'])+2*crt_offset)*100)/100, 
-                    'height':int((math.fabs(b['higher']['y']-b['lower']['y'])+2*crt_offset)*100)/100
+            factor=1/self.expected_grid
+            return { 'x': math.floor((b['lower']['x']-crt_offset)*factor)/factor, 
+                    'y':math.floor((b['lower']['y']-crt_offset)*factor)/factor, 
+                    'width':math.ceil((math.fabs(b['higher']['x']-b['lower']['x'])+2*crt_offset)*factor)/factor, 
+                    'height':math.ceil((math.fabs(b['higher']['y']-b['lower']['y'])+2*crt_offset)*factor)/factor
                    }
         else:
             return { 'x': 0, 'y':0, 'width':0, 'height':0}

--- a/pcb/rules/rule6_6.py
+++ b/pcb/rules/rule6_6.py
@@ -123,9 +123,9 @@ class Rule(KLCRule):
                 #print('b=',b)
                 if b['higher']['x']!=b['lower']['x'] and b['higher']['y']!=b['lower']['y'] and b['higher']['x']>-1.0E99 and b['higher']['y']>-1.0E99 and b['lower']['x']<1.0E99 and b['lower']['x']<1.0E99:
                     module_dir = os.path.split(os.path.dirname(os.path.realpath(module.filename)))[-1]
-                    self.module_dir = os.path.splitext(module_dir)
+                    self.module_dir = "{0}".format(os.path.splitext(module_dir))
                     crt_offset=0.25
-                    if re.match("BGA\-.*", module.name) or re.match(".*Housing.*BGA.*", self.module_dir):
+                    if re.match("BGA\-.*", module.name) or re.match(".*Housing.*BGA.*", module_dir):
                         crt_offset=1
                     elif re.match(".*Connector.*", module.name) or re.match(".*Connector.*", self.module_dir) or re.match(".*Socket.*", module.name) or re.match(".*Socket.*", self.module_dir):
                         crt_offset=0.5

--- a/pcb/rules/rule6_9.py
+++ b/pcb/rules/rule6_9.py
@@ -11,9 +11,9 @@ class Rule(KLCRule):
     """
     Create the methods check and fix to use with the kicad_mod files.
     """
-    def __init__(self, module):
+    def __init__(self, module, args):
         self.expected_width=0.1
-        super(Rule, self).__init__(module, 'Rule 6.9', "Fabrication layer contains an outline of the part using a {0}mm line width.".format(self.expected_width))
+        super(Rule, self).__init__(module, args, 'Rule 6.9', "Fabrication layer contains an outline of the part using a {0}mm line width.".format(self.expected_width))
 
     def check(self):
         """


### PR DESCRIPTION
- rule 10.3: now also replaces ';' as separator
- rule 10.5: now adds a user-text '%R' on F/B.Fab so the REFDES is visible on F.Fab AND F.SilkS (see new KLC)
- rule 6.6: 
    - now `--fix` will add a rectangular courtyard with 0.2mm offset to the pads and F.Fab (or F.SilkS if F.Fab does not exist) and if no CrtYd exists so far
    - now this rule can `--fix` a too-large/too-small courtyard rectangle. If the courtyard contains no rectangle with vertical7horizontal lines only it is not checked/altered (e.g. for packages with round courtyards, or advanced shapes)
- rule 6.3 now does not crash if pin1 does not exist + it tries to find A1 if 1 was not found + it now also moves the 3D model
- added rule 1.8, which checks for UNIX-style line-endings + `kicad_mod`-files are now explicitly saved with UNIX-style line-endings
- added a commandline-option `--addsilkscreenrect` that simply adds a silkscreen rectangle around what's found in the footprint (F.Fab, pads, ...)
- added a commandline-option `--rotate degrees` that rotates the full footprint by a given number of degrees (clock-wise), also rotates the 3D model correctly!