### PR TITLE
Rule 8.2: changed rule check to use overpadBounds() instead of padBounds()

### DIFF
--- a/pcb/kicad_mod.py
+++ b/pcb/kicad_mod.py
@@ -652,9 +652,10 @@ class KicadMod(object):
         return pads
         
     # Get the middle position between pads
+    # Use the outer dimensions of pads to handle footprints with pads of different sizes
     def padMiddlePosition(self, pads=None):
         
-        bb = self.padsBounds(pads)
+        bb = self.overpadsBounds(pads)
         return bb.center
 
     def padsBounds(self, pads=None):


### PR DESCRIPTION
See https://github.com/KiCad/kicad-library-utils/issues/98

### Change

```
    # Get the middle position between pads
    # Use the outer dimensions of pads to handle footprints with pads of different sizes
    def padMiddlePosition(self, pads=None):
        
        bb = self.overpadsBounds(pads)
        return bb.center
```

### Test data

[footprints.zip](https://github.com/KiCad/kicad-library-utils/files/900628/footprints.zip)

| Footprint | All pads same size | Anchor at centre|
|-|-|-|
| SOT-23| Yes | Yes |
| SOT-23_moved| Yes | No |
| TO-252-5-11| No | Yes |
| TO-252-2Lead| No | No |

### `check_kicad_mod.py` result for Rule 8.2

| Footprint | Expected result | Result with master | Result with PR |
|-|-|-|-|
| SOT-23|Pass| Pass | Pass |
| SOT-23_moved|Fail| Fail |Fail |
| TO-252-5-11|Pass| Fail <sup>1</sup> | Pass |
| TO-252-2Lead|Fail| Pass <sup>2</sup> | Fail |

__Notes__

<sup>1</sup> This incorrect result is what led to the issue being raised.

<sup>2</sup> This "false positive" for an existing footprint may be due to the footprint having been fixed before release by using the current version of `check_kicad_mod.py` with the `--fix` argument.

