### PR TITLE
Rule 9.6: fix division errors

### DIFF
--- a/pcb/rules/rule9_6.py
+++ b/pcb/rules/rule9_6.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import division
+
 from rules.rule import *
 
 class Rule(KLCRule):


### PR DESCRIPTION
Added `from __future__ import division` to ensure ring size is calculated as float even when pad and drill sizes are integers.

See: https://github.com/KiCad/kicad-library-utils/issues/109
