### PR TITLE
Rule 8.2: fix division errors for integer pad size

### DIFF
--- a/pcb/kicad_mod.py
+++ b/pcb/kicad_mod.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import division
+
 import time
 import re, math
 import sys, os


### PR DESCRIPTION
Added `from __future_ import division` to `kicad_mod.py`.

See https://github.com/KiCad/kicad-library-utils/issues/112