### PR TITLE
exception for KLC 4.3 which allows stacks with one poer input/output and all other pins PASSIVE and invisible

### DIFF
--- a/schlib/rules/rule4_3.py
+++ b/schlib/rules/rule4_3.py
@@ -38,6 +38,7 @@ class Rule(KLCRule):
         return pinString(pin, unit)
         
     def check(self):
+        self.component.padInSpecialPowerStack=set();
     
         # List of lists of pins that are entirely duplicated
         self.duplicated_pins = []
@@ -150,6 +151,7 @@ class Rule(KLCRule):
                         # in special pin stacks the power-input/power-output/output pin has to be visible and the passive pins need to be invisible
                         specialpincount=0
                         for pin in loc['pins']:
+                            self.component.padInSpecialPowerStack.add(pin['num'])
                             # check if all passive pins are invisible
                             if pin['electrical_type']=='P' and (not pin['pin_type'].startswith('N')):
                                 self.errorExtra("{pin} : {etype} should be invisible (power-pin stack)".format(
@@ -186,7 +188,7 @@ class Rule(KLCRule):
                             pin = self.pinStr(pin),
                             vis = 'INVISIBLE' if pin['pin_type'].startswith('N') else 'VISIBLE'))
                         self.only_one_visible=True
-						
+                        
         # check for invisible power I/O-pins (unless in power.lib)
         isPowerLib=(self.component.reference=='#PWR')
         if (not err) and (not isPowerLib):

--- a/schlib/rules/rule4_3.py
+++ b/schlib/rules/rule4_3.py
@@ -181,7 +181,7 @@ class Rule(KLCRule):
                         
                 # Only one pin should be visible (checks have already been done, when isSpecialXPassivePinStack=true)
                 if (not isSpecialXPassivePinStack) and (not vis_pin_count == 1):
-                    self.error(self.stackStr(loc) + " must have exactly one (1) invisible pin")
+                    self.error(self.stackStr(loc) + " must have exactly one (1) visible pin")
                     err = True
                     for pin in loc['pins']:
                         self.errorExtra("{pin} is {vis}".format(

--- a/schlib/rules/rule4_3.py
+++ b/schlib/rules/rule4_3.py
@@ -121,15 +121,34 @@ class Rule(KLCRule):
                         self.different_names=True
                             
                 # Different types!
-                if len(pin_etypes) > 1:
-                    self.error(self.stackStr(loc) + " have different types")
-                    err = True
-                    for pin in loc['pins']:
-                        self.errorExtra("{pin} : {etype}".format(
-                            pin = self.pinStr(pin),
-                            etype = pinElectricalTypeToStr(pin['electrical_type'])))
-                        self.different_types=True
-            
+                if (len(pin_etypes) > 1):
+                    powerpads=False;
+                    if (len(pin_etypes)==2) and ("W" in pin_etypes) and ("P" in pin_etypes):
+                        powerpads=True;
+                    if (len(pin_etypes)==2) and ("w" in pin_etypes) and ("P" in pin_etypes):
+                        powerpads=True;
+                    if not powerpads:
+                        self.error(self.stackStr(loc) + " have different types")
+                        err = True
+                        for pin in loc['pins']:
+                            self.errorExtra("{pin} : {etype}".format(
+                                pin = self.pinStr(pin),
+                                etype = pinElectricalTypeToStr(pin['electrical_type'])))
+                            self.different_types=True
+                    else:
+                        # in power-pin stacks the power-pin whould be visible and the passive pins invisible
+                        for pin in loc['pins']:
+                            if pin['electrical_type']=='P' and (not pin['pin_type'].startswith('N')):
+                                self.errorExtra("{pin} : {etype} should be invisible (power-pin stack)".format(
+                                    pin = self.pinStr(pin),
+                                    etype = pinElectricalTypeToStr(pin['electrical_type'])))
+                                err = True
+                            if (pin['electrical_type']=='W' or pin['electrical_type']=='w') and pin['pin_type'].startswith('N'):
+                                self.errorExtra("{pin} : {etype} should be visible (power-pin stack)".format(
+                                    pin = self.pinStr(pin),
+                                    etype = pinElectricalTypeToStr(pin['electrical_type'])))
+                                err = True
+                        
                 # Only one pin should be visible
                 if not vis_pin_count == 1:
                     self.error(self.stackStr(loc) + " must have exactly one (1) invisible pin")

--- a/schlib/rules/rule4_3.py
+++ b/schlib/rules/rule4_3.py
@@ -123,7 +123,7 @@ class Rule(KLCRule):
                 # Different types!
                 if (len(pin_etypes) > 1):
                     powerpads=False;
-                    if (len(pin_etypes)==2) and ("W" in pin_etypes) and ("P" in pin_etypes):
+                    if (len(pin_etypes)==2) and ("O" in pin_etypes) and ("P" in pin_etypes):
                         powerpads=True;
                     if (len(pin_etypes)==2) and ("w" in pin_etypes) and ("P" in pin_etypes):
                         powerpads=True;
@@ -143,8 +143,8 @@ class Rule(KLCRule):
                                     pin = self.pinStr(pin),
                                     etype = pinElectricalTypeToStr(pin['electrical_type'])))
                                 err = True
-                            if (pin['electrical_type']=='W' or pin['electrical_type']=='w') and pin['pin_type'].startswith('N'):
-                                self.errorExtra("{pin} : {etype} should be visible (power-pin stack)".format(
+                            if (pin['electrical_type']=='O' or pin['electrical_type']=='w') and pin['pin_type'].startswith('N'):
+                                self.errorExtra("{pin} : {etype} should be visible in a (power)-output pin stack".format(
                                     pin = self.pinStr(pin),
                                     etype = pinElectricalTypeToStr(pin['electrical_type'])))
                                 err = True

--- a/schlib/rules/rule4_6.py
+++ b/schlib/rules/rule4_6.py
@@ -54,7 +54,7 @@ class Rule(KLCRule):
             name = pin['name'].lower()
             etype = pin['electrical_type']
 
-            if self.test(name.lower(), self.POWER_INPUTS) and not etype.lower() == 'w':
+            if self.test(name.lower(), self.POWER_INPUTS) and (not etype.lower() == 'w') and (not pin['num'] in self.component.padInSpecialPowerStack):
                 if len(self.power_errors) == 0:
                     self.error("Power pins should be of type POWER INPUT or POWER OUTPUT")
                 self.power_errors.append(pin)

--- a/schlib/rules/rule4_6.py
+++ b/schlib/rules/rule4_6.py
@@ -64,7 +64,7 @@ class Rule(KLCRule):
                 if len(self.power_errors) == 0:
                     self.error("Power pins should be of type POWER INPUT or POWER OUTPUT")
                     if Rule43NotExecuted:
-                        self.errorExtra("NOTE: If power-pins have been stacked, you may ignore this error in some cases. Ensure to also check rule 4.3 in this case!")
+                        self.errorExtra("NOTE: If power-pins have been stacked, you may ignore this error in some cases (Ensure to check rule 4.3 in addition to recognize such stacks).")
                 self.power_errors.append(pin)
                 self.errorExtra("{pin} is of type {t}".format(
                     pin = pinString(pin),

--- a/schlib/rules/rule4_6.py
+++ b/schlib/rules/rule4_6.py
@@ -53,10 +53,18 @@ class Rule(KLCRule):
         for pin in pins:
             name = pin['name'].lower()
             etype = pin['electrical_type']
+			
+            inSpecialStack=False
+            Rule43NotExecuted=True
+            if hasattr(self.component, 'padInSpecialPowerStack'):
+                inSpecialStack=pin['num'] in self.component.padInSpecialPowerStack
+                Rule43NotExecuted=False
 
-            if self.test(name.lower(), self.POWER_INPUTS) and (not etype.lower() == 'w') and (not pin['num'] in self.component.padInSpecialPowerStack):
+            if self.test(name.lower(), self.POWER_INPUTS) and (not etype.lower() == 'w') and (not inSpecialStack):
                 if len(self.power_errors) == 0:
                     self.error("Power pins should be of type POWER INPUT or POWER OUTPUT")
+                    if Rule43NotExecuted:
+                        self.errorExtra("NOTE: If power-pins have been stacked, you may ignore this error in some cases. Ensure to also check rule 4.3 in this case!")
                 self.power_errors.append(pin)
                 self.errorExtra("{pin} is of type {t}".format(
                     pin = pinString(pin),


### PR DESCRIPTION
This is useful, especially for voltage regulators where several pins are tied together on the output ... to not cause ERC-violations, only one of the stacked pins may be POWER_OUT/IN all others should be PASSIVE (and invisible).

This fix enforces that!

Best,
JAN