### PR TITLE
additional debugging output with -vvv that shows the rules that should be run and the rule that is evaluated next

### DIFF
--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -61,6 +61,18 @@ for f in dir():
 #grab list of libfiles (even on windows!)
 libfiles = []
 
+if len(all_rules)<=0:
+    printer.red("No rules selected for check!")
+    sys.exit(1)
+else:
+    if (args.verbose>2):
+        printer.regular("checking rules:")	
+        for rule in all_rules:
+            printer.regular("  - "+str(rule))
+        printer.regular("")	
+
+
+
 for libfile in args.libfiles:
     libfiles += glob(libfile)
 
@@ -100,6 +112,8 @@ for libfile in libfiles:
     
         for rule in all_rules:
             rule = rule(component)
+            if (args.verbose>2):
+                printer.white("checking rule "+rule.name)	
             
             error = rule.check()
             


### PR DESCRIPTION
Just a small addition for debugging ... if run with `-vvv` the script to check KiCAD .lib-files lists the rules that it will check and if run with `-vvvv` later also outputs the name of each rule before it is checked:


```
D:\KiCAD\kicad-library-utils\schlib>checklib.py -vvv d:\KiCAD\kicad-library\libr
ary\regul.lib -pMC78l05_TO92
checking rules:
  - <class 'rules.rule4_1.Rule'>
  - <class 'rules.rule4_10.Rule'>
  - <class 'rules.rule4_11.Rule'>
  - <class 'rules.rule4_12.Rule'>
  - <class 'rules.rule4_2.Rule'>
  - <class 'rules.rule4_3.Rule'>
  - <class 'rules.rule4_5.Rule'>
  - <class 'rules.rule4_6.Rule'>
  - <class 'rules.rule4_7.Rule'>
  - <class 'rules.rule4_8.Rule'>
  - <class 'rules.rule4_9.Rule'>
  - <class 'rules.EC01.Rule'>

Checking symbol 'MC78L05_TO92' - No errors
```

```
D:\KiCAD\kicad-library-utils\schlib>checklib.py -vvvv d:\KiCAD\kicad-library\lib
rary\regul.lib -pMC78l05_TO92
checking rules:
  - <class 'rules.rule4_1.Rule'>
  - <class 'rules.rule4_10.Rule'>
  - <class 'rules.rule4_11.Rule'>
  - <class 'rules.rule4_12.Rule'>
  - <class 'rules.rule4_2.Rule'>
  - <class 'rules.rule4_3.Rule'>
  - <class 'rules.rule4_5.Rule'>
  - <class 'rules.rule4_6.Rule'>
  - <class 'rules.rule4_7.Rule'>
  - <class 'rules.rule4_8.Rule'>
  - <class 'rules.rule4_9.Rule'>
  - <class 'rules.EC01.Rule'>

checking rule Rule 4.1 - Pin placement
checking rule Rule 4.10 - Part metadata
checking rule Rule 4.11 - Default footprint
checking rule Rule 4.12 - Footprint filters
checking rule Rule 4.2 - Symbol visual style
checking rule Rule 4.3 - Pin stacking
checking rule Rule 4.5 - Pin orientation
checking rule Rule 4.6 - Pin types
checking rule Rule 4.7 - Unused pins
checking rule Rule 4.8 - Field text size
checking rule Rule 4.9 - Default fields
checking rule EC01 - Extra checking
Checking symbol 'MC78L05_TO92' - No errors
```