### PR TITLE
KLC-check scripts support graphical symbols and power-flag symbols now

### DIFF
--- a/common/rulebase.py
+++ b/common/rulebase.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 
 # Static functions
-def isValidName(name):
+def isValidName(name, checkForGraphicSymbol=False, checkForPowerSymbol=False):
         name = str(name).lower()
+        firstChar=True
         for c in name:
+            # first character may be '~' in some cases
+            if (checkForPowerSymbol or checkForGraphicSymbol) and firstChar and c=='~':
+                continue
+            
+            firstChar=False
             # Numeric characters check
             if c.isalnum():
                 continue
@@ -13,6 +19,9 @@ def isValidName(name):
                 continue
                 
             if c in ['_', '-', '.']:
+                continue
+            
+            if checkForPowerSymbol and (c in ['+']):
                 continue
             
             return False

--- a/schlib/rules/__init__.py
+++ b/schlib/rules/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
 "rule4_10",
 "rule4_11",
 "rule4_12", 
+"rule4_13", 
 "EC01",
 # Disable EC02 for now (way too confusing)
 # "EC02",

--- a/schlib/rules/__init__.py
+++ b/schlib/rules/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
 "rule4_11",
 "rule4_12", 
 "rule4_13", 
+"rule4_14", 
 "EC01",
 # Disable EC02 for now (way too confusing)
 # "EC02",

--- a/schlib/rules/rule4_10.py
+++ b/schlib/rules/rule4_10.py
@@ -20,19 +20,19 @@ class Rule(KLCRule):
         invalid_documentation = 0
 
         #check part itself
-        if self.checkDocumentation(self.component.name, self.component.documentation):
+        if self.checkDocumentation(self.component.name, self.component.documentation, False, self.component.isGraphicSymbol() or self.component.isPowerSymbol()):
             invalid_documentation += 1
 
         #check all its aliases too
         if self.component.aliases:
             invalid = []
             for alias in self.component.aliases.keys():
-                if self.checkDocumentation(alias, self.component.aliases[alias], True):
+                if self.checkDocumentation(alias, self.component.aliases[alias], True, self.component.isGraphicSymbol() or self.component.isPowerSymbol()):
                     invalid_documentation+=1
 
         return invalid_documentation > 0
 
-    def checkDocumentation(self, name, documentation, alias=False):
+    def checkDocumentation(self, name, documentation, alias=False, isGraphicOrPowerSymbol=False):
     
         errors = []
         warnings = []
@@ -47,7 +47,7 @@ class Rule(KLCRule):
                 errors.append("Missing DESCRIPTION field")
             if (not documentation['keywords']):
                 errors.append("Missing KEYWORDS field")
-            if (not documentation['datasheet']):
+            if (not isGraphicOrPowerSymbol) and (not documentation['datasheet']):
                 errors.append("Missing DATASHEET field")
                 
                 if (documentation['description'] and

--- a/schlib/rules/rule4_12.py
+++ b/schlib/rules/rule4_12.py
@@ -48,7 +48,7 @@ class Rule(KLCRule):
         
         filters = self.component.fplist
         
-        if len(filters) == 0:
+        if (not self.component.isGraphicSymbol() and not self.component.isPowerSymbol()) and len(filters) == 0:
             self.warning("No footprint filters defined")
             
         self.checkFilters(filters)

--- a/schlib/rules/rule4_13.py
+++ b/schlib/rules/rule4_13.py
@@ -8,11 +8,12 @@ class Rule(KLCRule):
     Create the methods check and fix to use with the kicad lib files.
     """
     def __init__(self, component):
-        super(Rule, self).__init__(component, 'Rule 4.13 - Power flag symbols', 'Power-flag symbols follow some special rules/KLC-exceptions')
+        super(Rule, self).__init__(component, 'Rule 4.13 - Power-flag symbols', 'Power-flag symbols follow some special rules/KLC-exceptions')
         self.makePinINVISIBLE=False
         self.makePinPowerInput=False
         self.fixTooManyPins=False
         self.fixPinSignalName=False
+        self.fixNoFootprint=False
 
     
     def check(self):
@@ -27,8 +28,8 @@ class Rule(KLCRule):
                 fail=True
                 self.fixTooManyPins=True
             else:
-                if (self.component.pins[0]['electrical_type'].lower() != 'w'):
-                    self.error("The pin in power-flag symbols has to be of a POWER-type")
+                if (self.component.pins[0]['electrical_type'] != 'W'):
+                    self.error("The pin in power-flag symbols has to be of a POWER-INPUT")
                     fail=True
                     self.makePinPowerInput=True
                 if (not self.component.pins[0]['pin_type'].startswith('N')):
@@ -39,6 +40,16 @@ class Rule(KLCRule):
                     self.error("The pin name ("+self.component.pins[0]['name']+") in power-flag symbols has to be the same as the component name ("+self.component.name+")")
                     fail=True
                     self.fixPinSignalName=True
+                # footprint field must be empty
+                if self.component.fields[2]['name']!='' and self.component.fields[2]['name']!='""':
+                    self.error("Graphical symbols have no footprint association (footprint was set to '"+self.component.fields[2]['name']+"')")
+                    fail=True
+                    self.fixNoFootprint=True
+                # FPFilters must be empty
+                if len(self.component.fplist)>0:
+                    self.error("Graphical symbols have no footprint filters")
+                    fail=True
+                    self.fixNoFootprint=True
         
         return fail
 
@@ -50,7 +61,7 @@ class Rule(KLCRule):
             self.info("FIX for too many pins in power-symbol not supported")
         if self.makePinPowerInput:
             self.info("FIX: switching pin-type to power-input")
-            self.component.pins[0]['electrical_type']='w'
+            self.component.pins[0]['electrical_type']='W'
         if self.makePinINVISIBLE:
             self.info("FIX: making pin invisible")
             self.component.pins[0]['pin_type']='N'+self.component.pins[0]['pin_type']
@@ -60,3 +71,7 @@ class Rule(KLCRule):
                 newname=self.component.name[1:len(self.component.name)]
             self.info("FIX: change pin name to '"+newname+"'")
             self.component.pins[0]['pin_type']='N'+self.component.pins[0]['pin_type']
+        if self.fixNoFootprint:
+            self.info("FIX empty footprint association and FPFilters")
+            self.component.fplist.clear()
+            self.component.fields[2]=''

--- a/schlib/rules/rule4_13.py
+++ b/schlib/rules/rule4_13.py
@@ -12,6 +12,7 @@ class Rule(KLCRule):
         self.makePinINVISIBLE=False
         self.makePinPowerInput=False
         self.fixTooManyPins=False
+        self.fixPinSignalName=False
 
     
     def check(self):
@@ -34,6 +35,10 @@ class Rule(KLCRule):
                     self.error("The pin in power-flag symbols has to be INVISIBLE")
                     fail=True
                     self.makePinINVISIBLE=True
+                if ((self.component.pins[0]['name'] != self.component.name) and ('~'+self.component.pins[0]['name'] != self.component.name)):
+                    self.error("The pin name ("+self.component.pins[0]['name']+") in power-flag symbols has to be the same as the component name ("+self.component.name+")")
+                    fail=True
+                    self.fixPinSignalName=True
         
         return fail
 
@@ -48,4 +53,10 @@ class Rule(KLCRule):
             self.component.pins[0]['electrical_type']='w'
         if self.makePinINVISIBLE:
             self.info("FIX: making pin invisible")
+            self.component.pins[0]['pin_type']='N'+self.component.pins[0]['pin_type']
+        if self.fixPinSignalName:
+            newname=self.component.name
+            if self.component.name.startswith('~'):
+                newname=self.component.name[1:len(self.component.name)]
+            self.info("FIX: change pin name to '"+newname+"'")
             self.component.pins[0]['pin_type']='N'+self.component.pins[0]['pin_type']

--- a/schlib/rules/rule4_13.py
+++ b/schlib/rules/rule4_13.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from rules.rule import *
+import re
+
+class Rule(KLCRule):
+    """
+    Create the methods check and fix to use with the kicad lib files.
+    """
+    def __init__(self, component):
+        super(Rule, self).__init__(component, 'Rule 4.13 - Power flag symbols', 'Power-flag symbols follow some special rules/KLC-exceptions')
+        self.makePinINVISIBLE=False
+        self.makePinPowerInput=False
+        self.fixTooManyPins=False
+
+    
+    def check(self):
+        """
+        Proceeds the checking of the rule.
+        """
+        
+        fail=False
+        if self.component.isPossiblyPowerSymbol():
+            if (len(self.component.pins) != 1):
+                self.error("Power-flag symbols have exactly one pin")
+                fail=True
+                self.fixTooManyPins=True
+            else:
+                if (self.component.pins[0]['electrical_type'].lower() != 'w'):
+                    self.error("The pin in power-flag symbols has to be of a POWER-type")
+                    fail=True
+                    self.makePinPowerInput=True
+                if (not self.component.pins[0]['pin_type'].startswith('N')):
+                    self.error("The pin in power-flag symbols has to be INVISIBLE")
+                    fail=True
+                    self.makePinINVISIBLE=True
+        
+        return fail
+
+    def fix(self):
+        """
+        Proceeds the fixing of the rule, if possible.
+        """
+        if self.fixTooManyPins:
+            self.info("FIX for too many pins in power-symbol not supported")
+        if self.makePinPowerInput:
+            self.info("FIX: switching pin-type to power-input")
+            self.component.pins[0]['electrical_type']='w'
+        if self.makePinINVISIBLE:
+            self.info("FIX: making pin invisible")
+            self.component.pins[0]['pin_type']='N'+self.component.pins[0]['pin_type']

--- a/schlib/rules/rule4_14.py
+++ b/schlib/rules/rule4_14.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from rules.rule import *
+import re
+
+class Rule(KLCRule):
+    """
+    Create the methods check and fix to use with the kicad lib files.
+    """
+    def __init__(self, component):
+        super(Rule, self).__init__(component, 'Rule 4.14 - Graphical symbols', 'Graphical symbols follow some special rules/KLC-exceptions')
+        self.fixTooManyPins=False
+        self.fixNoFootprint=False
+
+    
+    def check(self):
+        """
+        Proceeds the checking of the rule.
+        """
+        
+        fail=False
+        if self.component.isGraphicSymbol():
+            # no pins in raphical symbol
+            if (len(self.component.pins) != 0):
+                self.error("Graphical symbols have no pins")
+                fail=True
+                self.fixTooManyPins=True
+            # footprint field must be empty
+            if self.component.fields[2]['name']!='' and self.component.fields[2]['name']!='""':
+                self.error("Graphical symbols have no footprint association (footprint was set to '"+self.component.fields[2]['name']+"')")
+                fail=True
+                self.fixNoFootprint=True
+            # FPFilters must be empty
+            if len(self.component.fplist)>0:
+                self.error("Graphical symbols have no footprint filters")
+                fail=True
+                self.fixNoFootprint=True
+            
+        
+        return fail
+
+    def fix(self):
+        """
+        Proceeds the fixing of the rule, if possible.
+        """
+        if self.fixTooManyPins:
+            self.info("FIX for too many pins in graphical symbol not supported")
+        if self.fixNoFootprint:
+            self.info("FIX empty footprint association and FPFilters")
+            self.component.fplist.clear()
+            self.component.fields[2]=''

--- a/schlib/rules/rule4_2.py
+++ b/schlib/rules/rule4_2.py
@@ -17,7 +17,7 @@ class Rule(KLCRule):
         """
         
         # no checks for power-symbols or graphical symbols:
-        if self.component.isPowerSymbol() or self.component.isGraphicalSymbol():
+        if self.component.isPowerSymbol() or self.component.isGraphicSymbol():
             return False
         
         rectangle_need_fix = False

--- a/schlib/rules/rule4_2.py
+++ b/schlib/rules/rule4_2.py
@@ -15,6 +15,11 @@ class Rule(KLCRule):
         The following variables will be accessible after checking:
             * n_rectangles
         """
+        
+        # no checks for power-symbols or graphical symbols:
+        if self.component.isPowerSymbol() or self.component.isGraphicalSymbol():
+            return False
+        
         rectangle_need_fix = False
         # check if component has just one rectangle, if not, skip checking
         self.n_rectangles = len(self.component.draw['rectangles'])

--- a/schlib/rules/rule4_5.py
+++ b/schlib/rules/rule4_5.py
@@ -22,7 +22,7 @@ class Rule(KLCRule):
             for gnd in GND:
                 if re.search(gnd, name, flags=re.IGNORECASE) is not None:
                     # Pin orientation should be "up"
-                    if not pin['direction'] == 'U':
+                    if (not self.component.isPowerSymbol()) and (not pin['direction'] == 'U'):
                         if first:
                             first = False
                             self.warning("Ground and negative power pins should be placed at bottom of symbol")
@@ -40,7 +40,7 @@ class Rule(KLCRule):
             for pwr in PWR:
                 if re.search(pwr, name, flags=re.IGNORECASE) is not None:
                     # Pin orientation should be "down"
-                    if not pin['direction'] == 'D':
+                    if (not self.component.isPowerSymbol()) and not pin['direction'] == 'D':
                         if first:
                             first = False
                             self.warning("Positive power pins should be placed at top of symbol")

--- a/schlib/rules/rule4_9.py
+++ b/schlib/rules/rule4_9.py
@@ -26,10 +26,15 @@ class Rule(KLCRule):
 
         ref = self.component.fields[0]
 
-        if not self.checkVisibility(ref):
-            self.error("Ref field must be VISIBLE")
-            fail = True
-
+        if (not self.component.isGraphicSymbol()) and (not self.component.isPowerSymbol()):
+            if not self.checkVisibility(ref):
+                self.error("Ref(erence) field must be VISIBLE")
+                fail = True
+        else:
+            if self.checkVisibility(ref):
+                self.error("Ref(erence) field must be INVISIBLE in graphic symbols or power-symbols")
+                fail = True
+        
         return fail
 
     def checkValue(self):
@@ -42,19 +47,24 @@ class Rule(KLCRule):
         if name.startswith('"') and name.endswith('"'):
             name = name[1:-1]
 
-        if not name == self.component.name:
-            self.error("Value {val} does not match component name.".format(val=name))
-            fail = True
+        if (not self.component.isGraphicSymbol()) and (not self.component.isPowerSymbol()):
+            if not name == self.component.name:
+                self.error("Value {val} does not match component name.".format(val=name))
+                fail = True
+            # name field must be visible!
+            if not self.checkVisibility(value):
+                self.error("Value field must be VISIBLE")
+                fail = True
+        else:
+            if (not ('~'+name) == self.component.name) and (not name == self.component.name):
+                self.error("Value {val} does not match component name.".format(val=name))
+                fail = True
 
-        if not isValidName(self.component.name):
+        if not isValidName(self.component.name, self.component.isGraphicSymbol(), self.component.isPowerSymbol()):
             self.error("Symbol name '{val}' contains invalid characters as per KLC 1.7".format(
                 val = self.component.name))
             fail = True
 
-        # name field must be visible!
-        if not self.checkVisibility(value):
-            self.error("Value field must be VISIBLE")
-            fail = True
 
         return fail
 

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -286,10 +286,10 @@ class Component(object):
         return self.reference.startswith('#')
 
     def isPowerSymbol(self):
-        return (self.reference=='#PWR' or self.reference=='#FLG') and (len(self.pins)==1) and (self.pins[0]['electrical_type'].lower()=='w')
+        return (self.reference=='#PWR') and (len(self.pins)==1) and (self.pins[0]['electrical_type'].lower()=='w')
     
     def isPossiblyPowerSymbol(self):
-        return (self.reference=='#PWR' or self.reference=='#FLG') 
+        return (self.reference=='#PWR') 
 
     def isGraphicSymbol(self):
         return self.isNonBOMSymbol() and len(self.pins)==0

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -249,7 +249,10 @@ class Component(object):
 
     def getDocumentation(self,documentation,name):
         try:
-            return documentation.components[name]
+            if name.startswith('~'):
+                return documentation.components[name[1:(len(name))] ]
+            else:
+                return documentation.components[name]
         except KeyError:
             return {}
 
@@ -278,6 +281,20 @@ class Component(object):
                 pins.append(pin)
 
         return pins
+
+    def isNonBOMSymbol(self):
+        return self.reference.startswith('#')
+
+    def isPowerSymbol(self):
+        return (self.reference=='#PWR' or self.reference=='#FLG') and (len(self.pins)==1) and (self.pins[0]['electrical_type'].lower()=='w')
+    
+    def isPossiblyPowerSymbol(self):
+        return (self.reference=='#PWR' or self.reference=='#FLG') 
+
+    def isGraphicSymbol(self):
+        return self.isNonBOMSymbol() and len(self.pins)==0
+
+
 
 
 class SchLib(object):


### PR DESCRIPTION
@SchrodingersGat please have a look at these scripts:

- these modfications add support for graphical symbols (see PR https://github.com/KiCad/kicad-library/pull/1283).
- changes to KLC are proposed there: https://github.com/KiCad/kicad-library/issues/1287 (these also serve as documentation for the changes in this PR!!!)

Best, JAN

