### PR TITLE
Fixed parameter -p --path (Not working in initial Clone)

### DIFF
--- a/download_pretty_libs.py
+++ b/download_pretty_libs.py
@@ -79,6 +79,7 @@ def RepoUrl(repo):
 def CloneRepository(repo):
 
     # Clone
+    os.chdir(base_dir)
     Call(['git', 'clone', RepoUrl(repo)])
 
     return True


### PR DESCRIPTION
The -p and --path cmdline args are not working in initial clone.
I added os.chdir(base_dir) to go to the path defined with -p or --path cmdline args before execute the "git clone" command.
