### PR TITLE
Added script to check for footprint errors

### DIFF
--- a/check_symbol_footprints.py
+++ b/check_symbol_footprints.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Why even is this script?
+
+This script takes a bunch of symbol libraries (.lib files),
+and a whole heap of footprint libraries (.pretty directories),
+and determines which symbols need their footprint associations updated.
+
+Tests tested:
+
+a) Symbol is missing a footprint (this is OK, some are generic)
+b) Symbol footprint pattern is illegal (should be of the form <FpLib:FpName>)
+c) Referenced footprint library or footprint name is missing
+
+How to use?
+
+python check_symbol_footprints.py -h
+
+"""
+
+from __future__ import print_function
+
+import argparse
+import sys
+import os
+import os.path
+
+sys.path.append("schlib")
+
+import schlib
+
+parser = argparse.ArgumentParser(description="Check symbol footprint associations")
+parser.add_argument("symbols", help="Path to symbol libraries (.lib files) to check")
+parser.add_argument("footprints", help="Path to footprint libraries (.pretty dirs) to check")
+parser.add_argument("-a", "--all", help="Show all errors", action="store_true")
+parser.add_argument("-e", "--empty", help="Show symbols with empty footprints", action="store_true")
+parser.add_argument("-p", "--pattern", help="Show symbols with incorrect footprint pattern (LibName:FpName)", action="store_true")
+parser.add_argument("-n", "--name", help="Show symbols that point to an incorrect footprint", action="store_true")
+
+args = parser.parse_args()
+
+symbols_dir = args.symbols
+footprints_dir = args.footprints
+
+symbols = [f for f in os.listdir(symbols_dir) if f.endswith('.lib')]
+footprints = [f for f in os.listdir(footprints_dir) if f.endswith('.pretty')]
+
+"""
+Various classes of errors:
+
+- Footprint field is empty (no associated footprint)
+- Footprint field does not match Nickname:Fpname pattern
+- Footprint library 'nickname' does not exist
+- Footprint name 'Fpname' does not exist
+
+Each error type is stored in a dict, based on the library name
+Each error instance stores [symbol_name, footprint_text]
+
+"""
+
+err_fp_empty = {}
+err_fp_pattern = {}
+err_fp_nickname = {}
+err_fp_fpname = {}
+
+def addError(lib_name, sym_name, fp_text, err_dict):
+    if not lib_name in err_dict:
+        err_dict[lib_name] = []
+
+    err_dict[lib_name].append([sym_name, fp_text])
+
+
+def printError(err_dict):
+    for lib in err_dict:
+        print("-" * (9 + len(lib)))
+        print("Library:", lib)
+        for cmp in err_dict[lib]:
+            print(cmp[0], "->", cmp[1])
+
+
+# Construct a dictionary of Nickname:FpName
+# Remove the .pretty suffix from each directory
+# Remove the .kicad_mod suffix from each footprint
+fp_lib_list = {}
+
+for fp_lib in footprints:
+
+    pretty = os.path.join(footprints_dir, fp_lib)
+
+    if not pretty.endswith(".pretty") or not os.path.isdir(pretty):
+        continue
+
+    footprints = [f.replace('.kicad_mod', '') for f in os.listdir(pretty) if f.endswith('.kicad_mod')]
+    nickname = fp_lib.split(os.path.sep)[-1].replace('.pretty', '')
+    fp_lib_list[nickname] = footprints
+
+print("Checking libraries...\n")
+
+for sym_lib in symbols:
+    library = os.path.join(symbols_dir, sym_lib)
+
+    sch = schlib.SchLib(library)
+
+    for c in sch.components:
+        # Extract footprint and name information
+        cmp_name = c.name
+
+        # Empty footprint?
+        if not c.hasFootprint():
+            addError(sym_lib, cmp_name, '', err_fp_empty)
+            continue
+
+        fp = c.getFootprint()
+
+        fp_split = fp.split(":")
+
+        correct_pattern = len(fp_split) == 2 and len(fp_split[0]) > 0 and len(fp_split[1]) > 0
+
+        if not correct_pattern:
+            addError(sym_lib, cmp_name, fp, err_fp_pattern)
+            continue
+
+        fp_nickname, fp_name = fp_split
+
+        # Test that the footprint library (nickname) exists
+        if not fp_nickname in fp_lib_list:
+            addError(sym_lib, cmp_name, fp, err_fp_nickname)
+            continue
+
+        # Test that the footprint exists
+        fp_list = fp_lib_list[fp_nickname]
+
+        if not fp_name in fp_list:
+            addError(sym_lib, cmp_name, fp, err_fp_fpname)
+            continue
+
+# Print out the errors!
+
+if args.empty or args.all:
+    if len(err_fp_empty) > 0:
+        print("Symbols with empty footprint field:")
+        printError(err_fp_empty)
+
+if args.pattern or args.all:
+    if len(err_fp_pattern) > 0:
+        print("Symbols with incorrect footprint pattern:")
+        printError(err_fp_pattern)
+
+if args.name or args.all:
+    if len(err_fp_nickname) > 0:
+        print("Symbols pointing to missing fp library:")
+        printError(err_fp_nickname)
+    if len(err_fp_fpname) > 0:
+        print("Symbols pointing to missing footprint:")
+        printError(err_fp_fpname)

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -23,7 +23,7 @@ class Documentation(object):
         self.components = OrderedDict()
         self.validFile = False
         self.header = None
-        
+
         self.checksum = ""
 
         if create:
@@ -53,9 +53,9 @@ class Documentation(object):
 
         name = None
         f.seek(0)
-        
+
         checksum_data = ''
-        
+
         for line in f.readlines():
             checksum_data += line.strip()
             line = line.replace('\n', '')
@@ -75,14 +75,14 @@ class Documentation(object):
                 self.components[name] = OrderedDict([('description',description), ('keywords',keywords), ('datasheet',datasheet)])
             #FIXME: we do not handle comments except separators around components
         f.close()
-        
+
         try:
             md5 = hashlib.md5(checksum_data.encode('utf-8'))
         except UnicodeDecodeError:
             md5 = hashlib.md5(checksum_data)
-            
+
         self.checksum = md5.hexdigest()
-        
+
         return True
 
     def save(self, filename=None):
@@ -140,11 +140,11 @@ class Component(object):
         building_fplist = False
         building_draw = False
         building_fields = False
-        
+
         checksum_data = ''
-        
+
         self.resetDraw()
-        
+
         for line in data:
             checksum_data += line.strip()
             line = line.replace('\n', '')
@@ -236,7 +236,7 @@ class Component(object):
 
         # get documentation
         self.documentation = self.getDocumentation(documentation,self.name)
-        
+
     def resetDraw(self):
         self.draw = {
                     'arcs':[],
@@ -246,6 +246,22 @@ class Component(object):
                     'texts':[],
                     'pins':[]
                 }
+
+    def getFootprint(self):
+        if len(self.fields) < 3:
+            return ''
+        if 'name' in self.fields[2]:
+            fp = self.fields[2]['name']
+            fp = fp.replace('"', '')
+            fp = fp.replace("'", '')
+            return fp
+        return ''
+
+    def hasFootprint(self):
+        fp = self.getFootprint()
+        if fp is None or len(fp) == 0 or fp == "''" or fp =='""':
+            return False
+        return True
 
     def getDocumentation(self,documentation,name):
         try:
@@ -287,9 +303,9 @@ class Component(object):
 
     def isPowerSymbol(self):
         return (self.reference=='#PWR') and (len(self.pins)==1) and (self.pins[0]['electrical_type'].lower()=='w')
-    
+
     def isPossiblyPowerSymbol(self):
-        return (self.reference=='#PWR') 
+        return (self.reference=='#PWR')
 
     def isGraphicSymbol(self):
         return self.isNonBOMSymbol() and len(self.pins)==0
@@ -311,11 +327,11 @@ class SchLib(object):
         self.header = None
         self.components = []
         self.validFile = False
-        
+
         self.checksum = ""
 
         self.documentation = Documentation(self.libToDcmFilename(self.filename))
-        
+
         if create:
             if os.path.lexists(self.filename):
                 sys.stderr.write("File already exists!\n")
@@ -339,13 +355,13 @@ class SchLib(object):
 
     def __parse(self):
         f = open(self.filename, 'r')
-        
+
         checksum_data = ""
-        
+
         self.header = [f.readline()]
 
         checksum_data += self.header[0]
-        
+
         if self.header and not SchLib.line_keys['header'] in self.header[0]:
             sys.stderr.write("'{fn}' is not a KiCad Schematic Library File\n".format(fn=self.filename))
             return False
@@ -355,9 +371,9 @@ class SchLib(object):
 
         comments = []
         for line in f.readlines():
-        
+
             checksum_data += line.strip()
-        
+
             if line.startswith('#'):
                 comments.append(line)
 
@@ -373,31 +389,31 @@ class SchLib(object):
                     self.components.append(Component(component_data, comments, self.documentation))
                     comments = []
         f.close()
-        
+
         #perform checksum calculation
         try:
             md5 = hashlib.md5(checksum_data.encode('utf-8'))
         except UnicodeDecodeError:
             md5 = hashlib.md5(checksum_data)
         self.checksum = md5.hexdigest()
-        
+
         return True
-        
+
     def validChecksum(self):
         if len(self.checksum) == 0:
             return False
         if len(self.documentation.checksum) == 0:
             return False
-            
+
         return True
-        
+
     def compareChecksum(self, otherlib):
-    
+
         if not self.validChecksum() or not otherlib.validChecksum():
             return False
-    
+
         return self.checksum == otherlib.checksum and self.documentation.checksum == otherlib.documentation.checksum
-        
+
 
     def getComponentByName(self, name):
         for component in self.components:
@@ -457,10 +473,10 @@ class SchLib(object):
 
                 for k, key in enumerate(keys_list):
                     key_val = component.fields[i][key]
-                    
+
                     if k == 0 and not key_val.startswith('"'):
                         key_val = '"' + key_val + '"'
-                        
+
                     line += key_val + ' '
 
                 line = line.rstrip() + '\n'


### PR DESCRIPTION
Similar to the [3D model script](https://github.com/KiCad/kicad-library-utils/pull/117) submitted by @hackscribble this script checks a directory of .lib files to see where there may be footprint violations

- Checks empty footprint fields
- Checks for invalid footprint formatting
- Checks for footprints that do not exist

A good way to quickly show where effort needs to be directed to fix footprint associations.
