### PR TITLE
Formatting fix for rule 8.2

### DIFF
--- a/pcb/rules/rule8_2.py
+++ b/pcb/rules/rule8_2.py
@@ -25,19 +25,19 @@ class Rule(KLCRule):
             return False
 
         center = module.padMiddlePosition()
-        
+
         err = False
-        
+
         THRESHOLD = 0.001
         x = center['x']
         y = center['y']
-        
+
         if abs(x) > THRESHOLD or abs(y) > THRESHOLD:
             self.error("Footprint anchor is not located at center of footprint")
             self.errorExtra("Footprint center calculated as ({x},{y})mm".format(
-                x = center['x'],
-                y = center['y']))
-                
+                x = round(center['x'], 5),
+                y = round(center['y'], 5)))
+
             err = True
 
         return err
@@ -49,7 +49,7 @@ class Rule(KLCRule):
         module = self.module
         if self.check():
             self.info("Footprint anchor fixed")
-            
+
             center = module.padMiddlePosition()
-            
+
             module.setAnchor([center['x'], center['y']])


### PR DESCRIPTION
- Rounded displayed centre position, otherwise long trailing decimal points

This PR fixes the ugly decimal printing that can be found [at the bottom of this report](https://travis-ci.org/KiCad/Connectors.pretty/builds/257303131?utm_source=github_status&utm_medium=notification)