### PR TITLE
[WIP] STM32 autogen update

### DIFF
--- a/schlib/autogen/stm32/README.md
+++ b/schlib/autogen/stm32/README.md
@@ -5,11 +5,8 @@ This script turns XML files defining pins for STM32 devices into KiCAD libraries
 * XML files, taken from STM32CubeMX install (from db/mcu folder)
 * XML files for obsolete devices (currently STM32F050xx and STM32F313xx), which
   can be taken from STM32CubeMX install (archives in olddb folder)
-* Datasheet PDFs, downloaded from ST's website, current (21.02.2016) list could 
-  be found in datasheets.txt
-* [pdfminer](https://github.com/euske/pdfminer) tool
 
 ## Running
-If you have the correct XML files, just run `main.py path/to/xml path/to/pdfdir`, 
-where `path/to/Xdir` is the path to a directory containing all xml and pdf files. 
+If you have the correct XML files, just run `main.py path/to/xml`, 
+where `path/to/xml` is the path to a directory containing all xml files. 
 Make sure the XML files have the correct format as there is no error checking.

--- a/schlib/autogen/stm32/main.py
+++ b/schlib/autogen/stm32/main.py
@@ -460,7 +460,7 @@ class device:
         s += "F0 \"U\" " + str(round(- self.boxWidth / 2)) + " " + str(round(yOffset) + 25) + " 50 H V L B\r\n"
         s += "F1 \"" + self.name + "\" " + str(round(self.boxWidth / 2)) + " " + str(round(yOffset) + 25) + " 50 H V R B\r\n"
         s += "F2 \"" + self.package + "\" " + str(round(self.boxWidth / 2)) + " " + str(round(yOffset) - 25) + " 50 H I R T\r\n"
-        s += "F3 \"~\" 0 0 50 H V C CNN\r\n"
+        s += "F3 \"\" 0 0 50 H I C CNN\r\n"
         if (len(self.aliases) > 0):
             s += "ALIAS " + " ".join(self.aliases) + "\r\n"
         s += "DRAW\r\n"

--- a/schlib/autogen/stm32/main.py
+++ b/schlib/autogen/stm32/main.py
@@ -213,10 +213,10 @@ class device:
             if ((pin.pintype == "I/O" or pin.pintype == "Clock") and pin.name.startswith("P")):
                 port = pin.name[1]
                 try:
-                    self.ports[port][int(pin.name[2:])] = pin
+                    self.ports[port][int(re.sub("\D", "", pin.name[2:]))] = pin
                 except KeyError:
                     self.ports[port] = {}
-                    self.ports[port][int(pin.name[2:])] = pin
+                    self.ports[port][int(re.sub("\D", "", pin.name[2:]))] = pin
             elif (pin.pintype == "Clock"):
                 self.clockPins.append(pin)  
             elif ((pin.pintype == "Power") or (pin.name.startswith("VREF"))):

--- a/schlib/autogen/stm32/main.py
+++ b/schlib/autogen/stm32/main.py
@@ -459,7 +459,7 @@ class device:
         s += "DEF " + self.name + " U 0 40 Y Y 1 L N\r\n"
         s += "F0 \"U\" " + str(round(- self.boxWidth / 2)) + " " + str(round(yOffset) + 25) + " 50 H V L B\r\n"
         s += "F1 \"" + self.name + "\" " + str(round(self.boxWidth / 2)) + " " + str(round(yOffset) + 25) + " 50 H V R B\r\n"
-        s += "F2 \"" + self.package + "\" " + str(round(self.boxWidth / 2)) + " " + str(round(yOffset) - 25) + " 50 H V R T\r\n"
+        s += "F2 \"" + self.package + "\" " + str(round(self.boxWidth / 2)) + " " + str(round(yOffset) - 25) + " 50 H I R T\r\n"
         s += "F3 \"~\" 0 0 50 H V C CNN\r\n"
         if (len(self.aliases) > 0):
             s += "ALIAS " + " ".join(self.aliases) + "\r\n"

--- a/schlib/autogen/stm32/main.py
+++ b/schlib/autogen/stm32/main.py
@@ -58,6 +58,10 @@ class pin:
         self.y = 0;
         self.placed = False
 
+        # fix bogus NC type labeling
+        if self.name == "NC":
+            self.pintype = "NC"
+
     def createPintext(self, left):
         if (left):
             if (self.name == ""):

--- a/schlib/autogen/stm32/main.py
+++ b/schlib/autogen/stm32/main.py
@@ -62,19 +62,6 @@ class pin:
         if self.name == "NC":
             self.pintype = "NC"
 
-    def createPintext(self, left):
-        if (left):
-            if (self.name == ""):
-                s = "/".join(self.altfunctions + self.altNames)
-            else:
-                s = "/".join(self.altfunctions + self.altNames + [self.name])
-        else:
-            if (self.name == ""):
-                s = "/".join(self.altNames + self.altfunctions)
-            else:
-                s = "/".join([self.name] + self.altNames + self.altfunctions)
-        self.pintext = s.replace(" ","")
-
 class device:
     def __init__(self, xmlfile):
         print(xmlfile)
@@ -342,8 +329,7 @@ class device:
             size = 0
             for pin in self.pins:
                 if (pin.placed == True) and (int(pin.y) == i):
-                    pin.createPintext(False)
-                    size += len(pin.pintext)
+                    size += len(pin.name)
 
             if (maxXSize < size):
                 maxXSize = size
@@ -354,9 +340,8 @@ class device:
         for pin in self.topPins:
             pin.x = topX
             topX += 1
-            pin.createPintext(False)
-            if len(pin.pintext) > topMaxLen:
-                topMaxLen = len(pin.pintext)
+            if len(pin.name) > topMaxLen:
+                topMaxLen = len(pin.name)
                 
         bottomMaxLen = 0
         self.bottomPins = sorted(self.bottomPins, key=lambda p: p.name)
@@ -364,9 +349,8 @@ class device:
         for pin in self.bottomPins:
             pin.x = bottomX
             bottomX += 1
-            pin.createPintext(False)
-            if len(pin.pintext) > bottomMaxLen:
-                bottomMaxLen = len(pin.pintext)
+            if len(pin.name) > bottomMaxLen:
+                bottomMaxLen = len(pin.name)
         
         self.yTopMargin = math.ceil((topMaxLen * 47 + 75) / 100)
         self.yBottomMargin = math.ceil((bottomMaxLen * 47 + 75) / 100)
@@ -411,19 +395,17 @@ class device:
         
         y = 0
         for pin in self.rightPins:
-            pin.createPintext(True)
-            s += "X " + pin.pintext + " " + str(pin.pinnumber) + " " + str(int(self.boxWidth / 2 + pinlength)) + " " + str(round(yOffset - (pin.y + self.yTopMargin) * 100)) + " " + str(pinlength) + " L 50 50 1 1 " + PIN_TYPES_MAPPING[pin.pintype] + "\r\n"
+            s += "X " + pin.name + " " + str(pin.pinnumber) + " " + str(int(self.boxWidth / 2 + pinlength)) + " " + str(round(yOffset - (pin.y + self.yTopMargin) * 100)) + " " + str(pinlength) + " L 50 50 1 1 " + PIN_TYPES_MAPPING[pin.pintype] + "\r\n"
             y += 1
                 
         for pin in self.leftPins:
-            pin.createPintext(False)
-            s += "X " + pin.pintext + " " + str(pin.pinnumber) + " " + str(int(- self.boxWidth / 2 - pinlength)) + " " + str(round(yOffset - (pin.y + self.yTopMargin) * 100)) + " " + str(pinlength) + " R 50 50 1 1 " + PIN_TYPES_MAPPING[pin.pintype] + "\r\n"
+            s += "X " + pin.name + " " + str(pin.pinnumber) + " " + str(int(- self.boxWidth / 2 - pinlength)) + " " + str(round(yOffset - (pin.y + self.yTopMargin) * 100)) + " " + str(pinlength) + " R 50 50 1 1 " + PIN_TYPES_MAPPING[pin.pintype] + "\r\n"
             
         for pin in self.topPins:    
-            s += "X " + pin.pintext + " " + str(pin.pinnumber) + " " + str(int(pin.x * 100)) + " " + str(int(yOffset + pinlength)) + " " + str(pinlength) + " D 50 50 1 1 " + PIN_TYPES_MAPPING[pin.pintype] + "\r\n"
+            s += "X " + pin.name + " " + str(pin.pinnumber) + " " + str(int(pin.x * 100)) + " " + str(int(yOffset + pinlength)) + " " + str(pinlength) + " D 50 50 1 1 " + PIN_TYPES_MAPPING[pin.pintype] + "\r\n"
             
         for pin in self.bottomPins:
-            s += "X " + pin.pintext + " " + str(pin.pinnumber) + " " + str(int(pin.x * 100)) + " " + str(int(yOffset - self.boxHeight - pinlength)) + " " + str(pinlength) + " U 50 50 1 1 " + PIN_TYPES_MAPPING[pin.pintype] + "\r\n"
+            s += "X " + pin.name + " " + str(pin.pinnumber) + " " + str(int(pin.x * 100)) + " " + str(int(yOffset - self.boxHeight - pinlength)) + " " + str(pinlength) + " U 50 50 1 1 " + PIN_TYPES_MAPPING[pin.pintype] + "\r\n"
         
         s += "S -" + str(round(self.boxWidth / 2)) + " " + str(int(yOffset - self.boxHeight)) + " " + str(int(self.boxWidth / 2)) + " " + str(int(yOffset)) + " 0 1 10 f\r\n"
         s += "ENDDRAW\r\n"

--- a/schlib/autogen/stm32/main.py
+++ b/schlib/autogen/stm32/main.py
@@ -17,7 +17,7 @@ SPECIAL_PIN_MAPPING = {"VSS/TH": ["VSS/TH"],
 SPECIAL_TYPES_MAPPING = {"RCC_OSC_IN": "Clock", "RCC_OSC_OUT": "Clock"}
 
 PIN_TYPES_MAPPING = {"Power": "W", "I/O": "B", "Reset": "I", "Boot": "I", 
-                     "MonoIO": "B", "NC": "N", "Clock": "I"}
+                     "MonoIO": "B", "NC": "N N", "Clock": "I"}
 
 BOOT1_FIX_PARTS = {r"^STM32F10\d.+$", r"^STM32F2\d\d.+$", r"^STM32F4\d\d.+$", 
                    r"^STM32L1\d\d.+$"}


### PR DESCRIPTION
I am currently working on an update for the STM32 parts autogenerator. The changes added so far allow the script to run successfully on the current database of chips. The other changes adjust to the evolved KLC.

I've also changed the datasheet links as all datasheets can be accessed via `http://www.st.com/resource/en/datasheet/CHIPNUMBER.pdf`. This also allowed to remove the manual downloading of the pdfs.

Open issues:
- Packages are wrong. Currently the script just takes the name from the chip (e.g. LQFP64). This does not follow KLC and sadly isn't even unique. I am currently working on some hackery to get that information from the datasheets.
- Some chips violate rule 4.5 of KLC as the VBAT pins are not placed correctly. According to checklib they should be placed on top of symbol as they are positive power pins. It just seems to be a warning, should I change it anyways?