### PR TITLE
Added functionality to add tags as well as checking out specific tags

### DIFF
--- a/download_pretty_libs.py
+++ b/download_pretty_libs.py
@@ -14,6 +14,7 @@ import zipfile
 
 # Github address information
 GITHUB_URL = "https://www.github.com/KiCad"
+GITHUB_URL_SSH = "git@github.com:KiCad"
 GITHUB_FP_LIB_TABLE = "https://raw.githubusercontent.com/KiCad/kicad-library/master/template/fp-lib-table.for-github"
 FP_LIB_TABLE_FILE = "fp-lib-table.txt"
 
@@ -30,6 +31,11 @@ parser.add_argument("-i", "--ignore", help="Select which libraries to ignore (re
 parser.add_argument("-d", "--deprecated", help="Include libraries marked as deprecated", action="store_true")
 parser.add_argument("-u", "--update", help="Update libraries from github (no new libs will be downloaded)", action="store_true")
 parser.add_argument("-t", "--test", help="Test run only - libraries will be listed but not downloadded", action="store_true")
+parser.add_argument("--tag", help="Tag the current state of the libs", action="store")
+parser.add_argument("--push_tag", help="Push the tag to github. (ignored if --tag is not given.)", action="store_true")
+parser.add_argument("--checkout", help="Checkout a specific commit for all given repos. (Example a specific release tag)", action="store")
+parser.add_argument("--ssh", help="Use github ssh url for cloning libs", action="store_true")
+
 
 args = parser.parse_args()
 
@@ -73,6 +79,8 @@ def DownloadFile(url, save_file):
         return False
 
 def RepoUrl(repo):
+    if args.ssh:
+        return "{base}/{repo}".format(base=GITHUB_URL_SSH, repo=repo)
     return "{base}/{repo}".format(base=GITHUB_URL, repo=repo)
 
 # Git Clone a repository
@@ -98,6 +106,41 @@ def UpdateRepository(repo):
 
     os.chdir(path)
     Call(['git', 'pull'])
+    os.chdir(base_dir)
+
+# Perform git tag of the repository
+def TagRepository(repo, tag):
+    path = os.path.sep.join([base_dir, repo])
+
+    path = r"" + path
+
+    # Skip repo directories that do not exist
+    if not os.path.exists(path):
+        return
+
+    print("Taging {lib} with {tag}".format(lib=repo, tag=tag))
+
+    os.chdir(path)
+    Call(['git', 'tag', tag])
+    if args.push_tag:
+        print("Push tag {tag} to remote for {lib}".format(lib=repo, tag=tag))
+        Call(['git', 'push', 'origin', tag])
+    os.chdir(base_dir)
+
+# Perform git checkout of the repository
+def CheckoutRepository(repo, commit_id):
+    path = os.path.sep.join([base_dir, repo])
+
+    path = r"" + path
+
+    # Skip repo directories that do not exist
+    if not os.path.exists(path):
+        return
+
+    print("Taging {lib}".format(lib=repo))
+
+    os.chdir(path)
+    Call(['git', 'checkout', commit_id])
     os.chdir(base_dir)
 
 try:
@@ -141,6 +184,16 @@ for lib in libs:
     # If --update flag set, update library
     if args.update:
         UpdateRepository(url)
+        continue
+
+    # If --checkout flag set, checkout library to the given commit
+    if args.checkout:
+        CheckoutRepository(url, args.checkout)
+        continue
+
+    # If --tag flag set, tag library with the given tag
+    if args.tag:
+        TagRepository(url, args.tag)
         continue
 
     # Ignore libraries marked as 'deprecated'


### PR DESCRIPTION
This addition adds the following features:
- add a tag (tag given as option.)
- push a tag (option for the tag command)
- checkout a tag (or a branch would work as well)
- cloning using ssh instead of https protocol. (Necessary for push command. Otherwise password entry is necessary for each repo)

Tested with the recent adding of tags to all footprint libs.
I also checked if it can checkout other tags. Works as well.

Tested in linux (fedora 26)