### PR TITLE
Rule 4.10: align error message wording with UI names

### DIFF
--- a/schlib/rules/rule4_10.py
+++ b/schlib/rules/rule4_10.py
@@ -38,17 +38,17 @@ class Rule(KLCRule):
         warnings = []
     
         if not documentation:
-            errors.append("Missing all documentation fields (description, keywords, datasheet)")
+            errors.append("Missing all fields on 'Properties > Description' tab")
         elif (not documentation['description'] or
             not documentation['keywords'] or
             not documentation['datasheet']):
 
             if (not documentation['description']):
-                errors.append("Missing DESCRIPTION field")
+                errors.append("Missing DESCRIPTION field on 'Properties > Description' tab")
             if (not documentation['keywords']):
-                errors.append("Missing KEYWORDS field")
+                errors.append("Missing KEYWORDS field on 'Properties > Description' tab")
             if (not isGraphicOrPowerSymbol) and (not documentation['datasheet']):
-                errors.append("Missing DATASHEET field")
+                errors.append("Missing DOCUMENTATION FILE NAME field on 'Properties > Description' tab")
                 
                 if (documentation['description'] and
                     documentation['keywords']):


### PR DESCRIPTION
Following the discussion in https://github.com/KiCad/kicad-library/issues/1598, this PR aligns the error messages for missing metadata more closely with the tab and field names in the UI.

The proposed new messages are ...

```
Missing all fields on 'Properties > Description' tab
Missing DESCRIPTION field on 'Properties > Description' tab
Missing KEYWORDS field on 'Properties > Description' tab
Missing DOCUMENTATION FILE NAME field on 'Properties > Description' tab
```
