### PR TITLE
fixed up rule F9.3 (fixmore(), some default fix()-actions, ...)

### DIFF
--- a/pcb/check_kicad_mod.py
+++ b/pcb/check_kicad_mod.py
@@ -107,7 +107,13 @@ for filename in files:
             printer.yellow("Violating " + rule.name, indentation=2)
             rule.processOutput(printer, args.verbose, args.silent)
 
-        if error:
+        if args.fixmore and rule.needsFixMore:
+            if error:
+                n_violations += 1
+            rule.fixmore()
+            rule.fix()
+            rule.processOutput(printer, args.verbose, args.silent)
+        elif error:
             n_violations += 1
 
             if args.fix:

--- a/pcb/rules/F9_3.py
+++ b/pcb/rules/F9_3.py
@@ -20,10 +20,18 @@ class Rule(KLCRule):
         extensions = ["step", "stp", "wrl"]
 
         model = model['file']
+        
+        self.model3D_missingSYSMOD = False
+        self.model3D_wrongLib = False
+        self.model3D_wrongName = False
+        self.model3D_wrongFiletype = False
+        self.model3D_invalidName = False
 
         if model.startswith(SYSMOD_PREFIX):
             model = model.replace(SYSMOD_PREFIX,"")
         else:
+            self.model3D_missingSYSMOD = True
+            self.needsFixMore = True
             self.warning("Model path should start with '" + SYSMOD_PREFIX + "'")
 
         model_split = model.split("/")
@@ -43,6 +51,8 @@ class Rule(KLCRule):
 
         if not model_ext.lower() in extensions:
             self.error("Model '{mod}' is incompatible format (must be STEP or WRL file)".format(mod=model))
+            self.model3D_wrongFiletype = True
+            self.needsFixMore = True
             return True
 
         fp_dir = self.module_dir[0] + ".3dshapes"
@@ -50,18 +60,27 @@ class Rule(KLCRule):
 
         if not model_dir == fp_dir:
             self.error("3D model directory is different from footprint directory (found '{n1}', should be '{n2}')".format(n1=model_dir, n2=fp_dir))
+            self.model3D_wrongLib = True
+            self.needsFixMore = True
             error = True
 
         if not model_file == fp_name:
             # Exception for footprints that have additions e.g. "_ThermalPad"
             if fp_name.startswith(model_file) or model_file in fp_name or fp_name in model_file:
+                self.warning("3D model name is different from footprint name (found '{n1}', expected '{n2}'), but this might be intentionally!".format(n1=model_file, n2=fp_name))
+                self.needsFixMore = True
+                self.model3D_wrongName = True
+                error = False
                 pass
             else:
                 self.warning("3D model name is different from footprint name (found '{n1}', expected '{n2}')".format(n1=model_file, n2=fp_name))
+                self.needsFixMore = True
+                self.model3D_wrongName = True
                 error = True
 
         if not isValidName(model_file):
             error = True
+            self.model3D_invalidName = True
             self.error("3D model path '{p}' contains invalid characters as per KLC G1.1".format(
                 p = model_file))
 
@@ -76,17 +95,35 @@ class Rule(KLCRule):
             * model_file
         """
         module = self.module
+        
         module_dir = os.path.split(os.path.dirname(os.path.realpath(module.filename)))[-1]
         self.module_dir = os.path.splitext(module_dir)
 
         models = module.models
+        self.no3DModel = False
+        fp_dir = self.module_dir[0] + ".3dshapes"
+        fp_name = self.module.name
+        self.model3D_expectedDir = SYSMOD_PREFIX+fp_dir+'/';
+        self.model3D_expectedName = fp_name+'.wrl';
+        self.model3D_expectedFullPath = self.model3D_expectedDir+self.model3D_expectedName;
+        
+        
 
         if len(models) == 0:
             # Warning msg
-            self.warning("No 3D model provided")
-            return False
+            if module.attribute=='virtual':
+                # virtual components don't need a 3D model
+                self.warning("No 3D model provided for virtual component")
+                self.no3DModel = True
+                return False
+            else:
+                self.error("No 3D model provided")
+                self.no3DModel = True
+                return True
 
+        self.tooMany3DModel = False
         if len(models) > 1:
+            self.tooMany3DModel = True
             self.warning("More than one 3D model provided")
 
         model_error = False
@@ -98,4 +135,48 @@ class Rule(KLCRule):
         return model_error
 
     def fix(self):
+        """
+        Proceeds the fixing of the rule, if possible.
+        """
+        module = self.module
+        
+        # ensure all variables are set correctly
+        if self.no3DModel:
+            # model (default)
+            model_dict = {'file': self.model3D_expectedFullPath}
+            model_dict['pos'] = {'x':0, 'y':0, 'z':0}
+            model_dict['scale'] = {'x':1, 'y':1, 'z':1}
+            model_dict['rotate'] = {'x':0, 'y':0, 'z':0}
+            module.models.append(model_dict)
+            self.info("added default model '{model}' to footprint.".format(model=self.model3D_expectedFullPath))
+            return
+        elif not self.tooMany3DModel and (self.model3D_missingSYSMOD or self.model3D_wrongLib or self.model3D_wrongName):
+            if self.args.fixmore:
+                # model (default)
+                oldpath=module.models[0]['file']
+                module.models[0]['file']=self.model3D_expectedFullPath
+                self.info("fixed model path from '{oldmodel}' to '{model}'.".format(oldmodel=oldpath, model=self.model3D_expectedFullPath))
+                return
+            else:
+                self.info("Fix not supported by --fix, use --fixmore to fix this!")
+                return
+                
         self.info("Fix not supported")
+        return
+
+    def fixmore(self):
+        """
+        Proceeds the additional fixing of the rule, if possible and if --fixmore is provided as command-line argument.
+        """
+        module = self.module
+        
+        # ensure all variables are set correctly
+        if not self.tooMany3DModel and (self.model3D_missingSYSMOD or self.model3D_wrongLib or self.model3D_wrongName):
+            # model (default)
+            oldpath=module.models[0]['file']
+            module.models[0]['file']=self.model3D_expectedFullPath
+            self.info("fixed model path from '{oldmodel}' to '{model}'.".format(oldmodel=oldpath, model=self.model3D_expectedFullPath))
+            return
+                
+        self.info("FixMore not supported")
+        return

--- a/pcb/rules/rule.py
+++ b/pcb/rules/rule.py
@@ -87,6 +87,16 @@ class KLCRule(KLCRuleBase):
     
         self.module = module
         self.args = args
+        self.needsFixMore=False
 
         # Illegal chars
         self.illegal_chars = ['*', '?', ':', '/', '\\', '[', ']', ';', '|', '=', ',']
+
+    def fix(self):
+        self.info("fix not supported")
+        return
+        
+    def fixmore(self):
+        if self.needsFixMore:
+            self.info("fixmore not supported")
+        return


### PR DESCRIPTION
This reworks rule F9.3 (http://kicad-pcb.org/libraries/klc/#F9.3) with these features:
- if no model is provided at all: add default model in fix() unless this is a virtual component, which does not always require a 3D model (still all checks are done for virtuals, if models are specified!)
- if errors in 3D model path are there, --fixmore will replace the model path with the default path, which should fix most errors ... exceptions (warning-only), if the model-name starts with the default name, but has an extension (this should capture the e.g. SOT-23_LargePads which should have the same model as SOT-23).

+ for the --fixmore i made a default way to require thise fixes also in other rules (simply set self.needsFixMore=True and implement fixmore() ).

What do yout think?

JAN