### PR TITLE
Added option to save KLC error logs to file

### DIFF
--- a/common/rulebase.py
+++ b/common/rulebase.py
@@ -1,6 +1,45 @@
 # -*- coding: utf-8 -*-
 
 import inspect, os
+import json
+
+def logError(log_file, rule_name, lib_name, item_name, warning=False):
+    """
+    Log KLC error output to a json file.
+    The JSON file will contain a cumulative dict
+    of the errors and the library items that do not comply.
+    """
+
+    if not log_file.endswith('.json'):
+        log_file += '.json'
+
+    if os.path.exists(log_file) and os.path.isfile(log_file):
+        with open(log_file, 'r') as json_file:
+            try:
+                log_data = json.loads(json_file.read())
+            except:
+                print("Found bad JSON data - clearing")
+                log_data = {}
+
+    else:
+        log_data = {}
+
+    key = 'warnings' if warning else 'errors'
+
+    if not key in log_data:
+        log_data[key] = {}
+
+    log_entry = {'library': lib_name, 'item': item_name}
+
+    if not rule_name in log_data[key]:
+        log_data[key][rule_name] = []
+
+    log_data[key][rule_name].append(log_entry)
+
+    # Write the log data back to file
+    with open(log_file, 'w') as json_file:
+        op = json.dumps(log_data, indent=4, sort_keys=True, separators=(',', ':'))
+        json_file.write(op)
 
 # Static functions
 def isValidName(name, checkForGraphicSymbol=False, checkForPowerSymbol=False):

--- a/pcb/check_kicad_mod.py
+++ b/pcb/check_kicad_mod.py
@@ -16,6 +16,7 @@ from print_color import *
 from rules import __all__ as all_rules
 from rules import *
 from rules.rule import KLCRule
+from rulebase import logError
 
 # enable windows wildcards
 from glob import glob
@@ -30,6 +31,7 @@ parser.add_argument('--nocolor', help='does not use colors to show the output', 
 parser.add_argument('-v', '--verbose', help='Enable verbose output. -v shows brief information, -vv shows complete information', action='count')
 parser.add_argument('-s', '--silent', help='skip output for symbols passing all checks', action='store_true')
 parser.add_argument('-e', '--errors', help='Do not suppress fatal parsing errors', action='store_true')
+parser.add_argument('-l', '--log', help="Path to JSON file to log error information")
 
 args = parser.parse_args()
 if args.fixmore:
@@ -70,6 +72,8 @@ for filename in files:
         printer.red('File is not a .kicad_mod : %s' % filename)
         continue
 
+    lib_name = os.path.dirname(filename).split(os.path.sep)[-1].replace('.pretty', '')
+
     if args.errors:
         module = KicadMod(filename)
     else:
@@ -109,6 +113,9 @@ for filename in files:
 
         if error:
             n_violations += 1
+
+            if args.log:
+                logError(args.log, rule.name, lib_name, module.name)
 
             if args.fix:
                 rule.fix()

--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -16,6 +16,7 @@ import re
 from rules import __all__ as all_rules
 from rules import *
 from rules.rule import KLCRule
+from rulebase import logError
 
 #enable windows wildcards
 from glob import glob
@@ -29,6 +30,7 @@ parser.add_argument('--fix', help='fix the violations if possible', action='stor
 parser.add_argument('--nocolor', help='does not use colors to show the output', action='store_true')
 parser.add_argument('-v', '--verbose', help='Enable verbose output. -v shows brief information, -vv shows complete information', action='count')
 parser.add_argument('-s', '--silent', help='skip output for symbols passing all checks', action='store_true')
+parser.add_argument('-l', '--log', help='Path to JSON file to log error information')
 
 args = parser.parse_args()
 
@@ -78,6 +80,10 @@ exit_code = 0
 
 for libfile in libfiles:
     lib = SchLib(libfile)
+
+    # Remove .lib from end of name
+    lib_name = os.path.basename(libfile)[:-4]
+
     n_components = 0
 
     # Print library name
@@ -122,6 +128,9 @@ for libfile in libfiles:
             # Specifically check for errors
             if error:
                 n_violations += 1
+
+                if args.log:
+                    logError(args.log, rule.name, lib_name, component.name)
 
                 if args.fix:
                     rule.fix()


### PR DESCRIPTION
This PR adds function to save error messages to a log file (JSON)

Required for an idea I have to link users to the appropriate KLC page on the KiCad website when they submit a PR