### PR TITLE
Fix for --fix

### DIFF
--- a/pcb/check_kicad_mod.py
+++ b/pcb/check_kicad_mod.py
@@ -130,7 +130,7 @@ for filename in files:
     if n_violations > 0:
         exit_code += 1
 
-    if args.fix or args.rotate!=0:
+    if (args.fix and n_violations > 0) or args.rotate!=0:
         module.save()
 
 if args.fix:

--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -145,7 +145,7 @@ for libfile in libfiles:
         if n_violations > 0:
             exit_code += 1
 
-    if args.fix:
+    if args.fix and n_violations > 0:
         lib.save()
 
 sys.exit(exit_code);


### PR DESCRIPTION
--fix option previously created noise on ALL files (even those without errors)
Now it only saves files that have violations
Still room for some file noise, but much less