### PR TITLE
Remove requirement to return 'true' or 'false' in check()

### DIFF
--- a/common/rulebase.py
+++ b/common/rulebase.py
@@ -94,18 +94,43 @@ class KLCRuleBase(object):
     def __init__(self, description):
         self.description = description
         self.messageBuffer=[]
+        self.resetErrorCount()
+        self.resetWarningCount()
+
+
+    def resetErrorCount(self):
+        self.error_count = 0
+
+    def resetWarningCount(self):
+        self.warning_count = 0
+
+    @property
+    def errorCount(self):
+        return self.error_count
+
+    def hasErrors(self):
+        return self.error_count > 0
+
+    def warningCount(self):
+        return self.warning_count
+
+    @property
+    def hasWarnings(self):
+        return self.warning_count > 0
 
     #adds message into buffer only if such level of verbosity is wanted
     def verboseOut(self, msgVerbosity, severity, message):
         self.messageBuffer.append([message,msgVerbosity,severity])
 
     def warning(self, msg):
+        self.warning_count += 1
         self.verboseOut(Verbosity.NORMAL, Severity.WARNING, msg)
 
     def warningExtra(self, msg):
         self.verboseOut(Verbosity.HIGH, Severity.WARNING, " - " + msg)
 
     def error(self, msg):
+        self.error_count += 1
         self.verboseOut(Verbosity.NORMAL, Severity.ERROR, msg)
 
     def errorExtra(self, msg):
@@ -124,8 +149,14 @@ class KLCRuleBase(object):
         raise NotImplementedError('The fix method must be implemented')
 
     def recheck(self):
-        if self.check():
-            self.error("Could not be fixed")
+
+        self.resetErrorCount()
+        self.resetWarningCount()
+
+        self.check()
+
+        if self.hasErrors():
+            self.error("Could not fix all errors")
         else:
             self.success("Everything fixed")
 

--- a/pcb/check_kicad_mod.py
+++ b/pcb/check_kicad_mod.py
@@ -32,12 +32,20 @@ parser.add_argument('-v', '--verbose', help='Enable verbose output. -v shows bri
 parser.add_argument('-s', '--silent', help='skip output for symbols passing all checks', action='store_true')
 parser.add_argument('-e', '--errors', help='Do not suppress fatal parsing errors', action='store_true')
 parser.add_argument('-l', '--log', help="Path to JSON file to log error information")
+parser.add_argument('-w', '--nowarnings', help='Hide warnings (only show errors)', action='store_true')
 
 args = parser.parse_args()
 if args.fixmore:
     args.fix=True
 
 printer = PrintColor(use_color=not args.nocolor)
+
+# Set verbosity globally
+verbosity = 0
+if args.verbose:
+    verbosity = args.verbose
+
+KLCRule.verbosity = verbosity
 
 exit_code = 0
 
@@ -101,7 +109,13 @@ for filename in files:
     for rule in rules:
         rule = rule(module,args)
 
-        error = rule.check()
+        if verbosity > 2:
+            printer.white("Checking rule " + rule.name)
+
+        rule.check()
+
+        if args.nowarnings and not rule.hasErrors():
+            continue
 
         if rule.hasOutput():
             if first:
@@ -111,8 +125,8 @@ for filename in files:
             printer.yellow("Violating " + rule.name, indentation=2)
             rule.processOutput(printer, args.verbose, args.silent)
 
-        if error:
-            n_violations += 1
+        if rule.hasErrors():
+            n_violations += rule.errorCount
 
             if args.log:
                 logError(args.log, rule.name, lib_name, module.name)
@@ -120,6 +134,7 @@ for filename in files:
             if args.fix:
                 rule.fix()
                 rule.processOutput(printer, args.verbose, args.silent)
+                rule.recheck()
 
     # No messages?
     if first:


### PR DESCRIPTION
- Error count incremented when error() is called
- Warning count incremented when warning() is called
- Also added --nowarning option to hide warning output

Currently each rule must return "true" or "false" from the check() function based on whether an error was thrown. 

This is tedious and prone to error. Currently there are a number of rules where errors have been changed to warnings but still return non-zero error codes.

Now, the base Rule class contains an error count and a warning count which are auto-incremented when error() and warning() are called.