### PR TITLE
bugfix: F5.3 used the wrong layer-names for silkscreen

### DIFF
--- a/pcb/rules/F5_3.py
+++ b/pcb/rules/F5_3.py
@@ -29,13 +29,15 @@ class Rule(KLCRule):
         padBounds = module.overpadsBounds()
 
         # Try getting bounds from these layers, in order
-        layers = ['F.Fab', 'B.Fab', 'F.Silk', 'B.Silk']
+        layers = ['F.Fab', 'B.Fab', 'F.SilkS', 'B.SilkS']
 
         # Accept first valid layer
         for layer in layers:
             geo = module.geometricBoundingBox(layer)
             if geo.valid:
+                print("using drawing from layer", layer)
                 break
+            else:
 
         # Add two bounding boxes together
         padBounds.addBoundingBox(geo)


### PR DESCRIPTION
the scripts did not create a correct courtyard on old footpritns without drawing on F.Fab!

