### PR TITLE
Add footprint checker to S5.1

### DIFF
--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -32,6 +32,7 @@ parser.add_argument('-v', '--verbose', help='Enable verbose output. -v shows bri
 parser.add_argument('-s', '--silent', help='skip output for symbols passing all checks', action='store_true')
 parser.add_argument('-l', '--log', help='Path to JSON file to log error information')
 parser.add_argument('-w', '--nowarnings', help='Hide warnings (only show errors)', action='store_true')
+parser.add_argument('--footprints', help='Path to footprint libraries (.pretty dirs). Specify with e.g. "~/kicad/footprints/"')
 
 args = parser.parse_args()
 
@@ -113,6 +114,10 @@ for libfile in libfiles:
 
         for rule in rules:
             rule = rule(component)
+
+            if args.footprints:
+                rule.footprints_dir = args.footprints
+
             if verbosity > 2:
                 printer.white("checking rule" + rule.name)
 

--- a/schlib/rules/S5_1.py
+++ b/schlib/rules/S5_1.py
@@ -54,6 +54,24 @@ class Rule(KLCRule):
                         self.error("Footprint name '{f}' contains illegal characters".format(f=fp_path))
                         fail = True
 
+                    # Check that the footprint exists!
+                    if not fail:
+                        if self.footprints_dir and os.path.exists(self.footprints_dir) and os.path.isdir(self.footprints_dir):
+
+                            fp_libs = [x.replace('.pretty', '') for x in os.listdir(self.footprints_dir) if x.endswith('.pretty')]
+
+                            if not fp_dir in fp_libs:
+                                self.error('Specified footprint library does not exist')
+                                self.errorExtra("Footprint library '{l}' was not found".format(l=fp_dir))
+                            else:
+                                fp_dir = os.path.join(self.footprints_dir, fp_dir + ".pretty")
+                                fp_file = os.path.join(fp_dir, fp_path + '.kicad_mod')
+
+                                if not os.path.exists(fp_file):
+                                    self.warning("Specified footprint does not exist")
+                                    self.warningExtra("Footprint file {l}:{f} was not found".format(l=fp_dir, f=fp_path))
+
+
         return fail
 
     def fix(self):


### PR DESCRIPTION
- Pass path to footprint files
- S5.1 checks if the specified footprint library or file actually exists

This addition can be used in conjunction with Travis to download the current footprint library and check if the specified footprint exists.

A missing **library** is an error. A missing **footprint** is just a warning (maybe the footprint hasn't been submitted yet)?