### PR TITLE
Lib compare improvements

### DIFF
--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -117,6 +117,8 @@ for libfile in libfiles:
 
             if args.footprints:
                 rule.footprints_dir = args.footprints
+            else:
+                rule.footprints_dir = None
 
             if verbosity > 2:
                 printer.white("checking rule" + rule.name)

--- a/schlib/comparelibs.py
+++ b/schlib/comparelibs.py
@@ -13,6 +13,7 @@ This is to be used to compare an updated library file with a previous version to
 import argparse
 import sys
 import os
+from glob import glob
 
 # Path to common directory
 common = os.path.abspath(os.path.join(sys.path[0], '..','common'))
@@ -29,8 +30,8 @@ def ExitError( msg ):
 
 parser = argparse.ArgumentParser(description="Compare two .lib files to determine which symbols have changed")
 
-parser.add_argument("--new", help="New (updated) .lib file(s)")
-parser.add_argument("--old", help="Old (original) .lib file(s) for comparison")
+parser.add_argument("--new", help="New (updated) .lib file(s)", nargs='+')
+parser.add_argument("--old", help="Old (original) .lib file(s) for comparison", nargs='+')
 parser.add_argument("-v", "--verbose", help="Enable extra verbose output", action="store_true")
 parser.add_argument("--check", help="Perform KLC check on updated/added components", action='store_true')
 parser.add_argument("--nocolor", help="Does not use colors to show the output", action='store_true')
@@ -40,14 +41,14 @@ parser.add_argument('extra', help='Extra arguments will be passed to the checkli
 args,extra = parser.parse_known_args()
 
 if not args.new:
-    ExitError("New file not supplied")
+    ExitError("New file(s) not supplied")
 
 if not args.old:
-    ExitError("Original file not supplied")
+    ExitError("Original file(s) not supplied")
 
-def KLCCheck(component):
+def KLCCheck(lib, component):
+    
     # Wrap library in "quotes" if required
-    lib = args.new
     if " " in lib and '"' not in lib:
         lib = '"' + lib + '"'
 
@@ -65,78 +66,103 @@ def KLCCheck(component):
 
 printer = PrintColor(use_color = not args.nocolor)
 
-new_lib = SchLib( args.new )
-old_lib = SchLib( args.old )
+new_libs = {}
+old_libs = {}
 
-# If the libs themselves are unchanged, ignore!
-if new_lib.compareChecksum(old_lib):
-    # exit silently
-    sys.exit(0)
+for lib in args.new:
+    libs = glob(lib)
+    
+    for l in libs:
+        if l.endswith('.lib') and os.path.exists(l):
+            new_libs[os.path.basename(l)] = os.path.abspath(l)
+            
+for lib in args.old:
+    libs = glob(lib)
+    
+    for l in libs:
+        if l.endswith('.lib') and os.path.exists(l):
+            old_libs[os.path.basename(l)] = os.path.abspath(l)
+    
+errors = 0            
+            
+for lib_name in new_libs:
 
-# Dicts of name:checksum pairs
-new_chk = {}
-old_chk = {}
+    lib_path = new_libs[lib_name]
+    new_lib = SchLib(lib_path)
+    
 
-deleted = []
-added = []
-updated = []
+    # New library has been created!
+    if not lib_name in old_libs:
 
-errors = 0
-
-for cmp in new_lib.components:
-    new_chk[cmp.name] = cmp.checksum
-
-for cmp in old_lib.components:
-    old_chk[cmp.name] = cmp.checksum
-
-for name in old_chk.keys():
-    # First, check if any components have been deleted
-    if not name in new_chk:
-        deleted.append(name)
+        if args.verbose:
+            printer.light_green("Created library '{lib}'".format(lib=lib_name))
+        
+        # Check all the components!
+        for cmp in new_lib.components:
+            
+            if args.check:
+                if not KLCCheck(lib_path, cmp.name) == 0:
+                    errors += 1
+                    
+    
         continue
+        
+    # Library has been updated - check each component to see if it has been changed
+    old_lib_path = old_libs[lib_name]
+    old_lib = SchLib(old_lib_path)
+    
+    # If library checksums match, we can skip entire library check
+    if new_lib.compareChecksum(old_lib):
+        if args.verbose:
+            printer.yellow("No changes to library '{lib}'".format(lib=lib_name))
+        continue
+    
+    new_cmp = {}
+    old_cmp = {}
+    
+    for cmp in new_lib.components:
+        new_cmp[cmp.name] = cmp
+        
+    for cmp in old_lib.components:
+        old_cmp[cmp.name] = cmp
+        
+    for cmp in new_cmp:
+        # Component is 'new' (not in old library)
+        if not cmp in old_cmp:
+            
+            if args.verbose:
+                printer.light_green("New symbol '{lib}:{name}'".format(lib=lib_name, name=cmp))
+            
+            if args.check:
+                if not KLCCheck(lib_path, cmp) == 0:
+                    errors += 1
+        
+            continue
+            
+        chk_new = new_cmp[cmp].checksum
+        chk_old = old_cmp[cmp].checksum
+        
+        if not chk_old == chk_new:
 
-    # Next, check for checksum mismatch
-    if not old_chk[name] == new_chk[name]:
-        updated.append(name)
-
-# Finally, check for NEW components
-for name in new_chk.keys():
-    if not name in old_chk:
-        added.append(name)
-
-# Display any deleted components
-if len(deleted) > 0:
-    if args.verbose:
-        printer.light_red("Components Removed: {n}".format(n=len(deleted)))
-    for cmp in deleted:
-        printer.light_red("- " + cmp)
-
-# Display any added components
-if len(added) > 0:
-    if args.verbose:
-        printer.light_green("Components Added: {n}".format(n=len(added)))
-    for cmp in added:
-        printer.light_green("+ " + cmp)
-
-        # Perform KLC check on component
-        if args.check:
-            if KLCCheck(cmp) is not 0:
-                errors += 1
-
-# Display any updated components
-if len(updated) > 0:
-    if args.verbose:
-        printer.yellow("Components Updated: {n}".format(n=len(updated)))
-    for cmp in updated:
-        printer.yellow("# " + cmp)
-
-        # perform KLC check on component
-        if args.check:
-            if KLCCheck(cmp) is not 0:
-                errors += 1
-
-if args.verbose and len(deleted) == 0 and len(added) == 0 and len(updated) == 0:
-    printer.green("No component variations found")
+            if args.verbose:
+                printer.yellow("Changed symbol '{lib}:{name}'".format(lib=lib_name, name=cmp))
+            if args.check:
+                if not KLCCheck(lib_path, cmp) == 0:
+                    errors += 1
+                    
+            
+        
+    for cmp in old_cmp:
+        # Component has been deleted from library
+        if not cmp in new_cmp:
+            if args.verbose:
+                printer.red("Removed symbol '{lib}:{name}'".format(lib=lib_name, name=cmp))
+            
+# Entire lib has been deleted?
+for lib_name in old_libs:
+    if not lib_name in new_libs:
+        if args.verbose:
+            printer.red("Removed library '{lib}'".format(lib=lib_name))
 
 # Return the number of errors found ( zero if --check is not set )
 sys.exit(errors)

--- a/schlib/comparelibs.py
+++ b/schlib/comparelibs.py
@@ -29,13 +29,15 @@ def ExitError( msg ):
 
 parser = argparse.ArgumentParser(description="Compare two .lib files to determine which symbols have changed")
 
-parser.add_argument("--new", help="New (updated) .lib file")
-parser.add_argument("--old", help="Old (original) .lib file for comparison")
+parser.add_argument("--new", help="New (updated) .lib file(s)")
+parser.add_argument("--old", help="Old (original) .lib file(s) for comparison")
 parser.add_argument("-v", "--verbose", help="Enable extra verbose output", action="store_true")
 parser.add_argument("--check", help="Perform KLC check on updated/added components", action='store_true')
 parser.add_argument("--nocolor", help="Does not use colors to show the output", action='store_true')
 
-args = parser.parse_args()
+parser.add_argument('extra', help='Extra arguments will be passed to the checklib script', nargs=argparse.REMAINDER)
+
+args,extra = parser.parse_known_args()
 
 if not args.new:
     ExitError("New file not supplied")
@@ -54,7 +56,11 @@ def KLCCheck(component):
                 cmp = component,
                 nocolor = "--nocolor" if args.nocolor else ""
                 )
-
+                
+    # Pass extra arguments to checklib script
+    if len(extra) > 0:
+        call += ' '.join([str(e) for e in extra])
+        
     return os.system(call)
 
 printer = PrintColor(use_color = not args.nocolor)

--- a/schlib/comparelibs.py
+++ b/schlib/comparelibs.py
@@ -36,8 +36,6 @@ parser.add_argument("-v", "--verbose", help="Enable extra verbose output", actio
 parser.add_argument("--check", help="Perform KLC check on updated/added components", action='store_true')
 parser.add_argument("--nocolor", help="Does not use colors to show the output", action='store_true')
 
-parser.add_argument('extra', help='Extra arguments will be passed to the checklib script', nargs=argparse.REMAINDER)
-
 args,extra = parser.parse_known_args()
 
 if not args.new:


### PR DESCRIPTION
This PR improves the comparelibs.py script to allow for better checking of the new `kicad-symbols` repo

* Passes extra arguments through to `checklib.py`
* Better output
* Gracefully handles missing libraries
* Can pass multiple libraries at the command line
* Bug fix for checklib.py