### PR TITLE
Calculate center of symbol outline for origin

### DIFF
--- a/schlib/rules/S3_1.py
+++ b/schlib/rules/S3_1.py
@@ -26,28 +26,18 @@ class Rule(KLCRule):
             x = (int(rect['startx']) + int(rect['endx'])) // 2
             y = (int(rect['starty']) + int(rect['endy'])) // 2
         else:
-            x_min = y_min = x_max = y_max = None
-
             pins = self.component.pins
 
             # No pins? Ignore check.
             # This can be improved to include graphical items too...
             if len(pins) == 0:
                 return False
-
-            for i, p in enumerate(pins):
-
-                x = int(p['posx'])
-                y = int(p['posy'])
-
-                if i == 0:
-                    x_min = x_max = x
-                    y_min = y_max = y
-                else:
-                    x_min = min(x_min, x)
-                    x_max = max(x_max, x)
-                    y_min = min(y_min, y)
-                    y_max = max(y_max, y)
+            x_pos = [int(pin['posx']) for pin in pins]
+            y_pos = [int(pin['posy']) for pin in pins]
+            x_min = min(x_pos)
+            x_max = max(x_pos)
+            y_min = min(y_pos)
+            y_max = max(y_pos)
 
             # Center point average
             x = (x_min + x_max) / 2

--- a/schlib/rules/S3_1.py
+++ b/schlib/rules/S3_1.py
@@ -10,37 +10,48 @@ class Rule(KLCRule):
         super(Rule, self).__init__(component, 'Origin is be centered on the middle of the symbol')
 
     def check(self):
-
         """
-        Calculate the 'bounds' of the symbol based on pin locations
+        Calculate the 'bounds' of the symbol based on rectangle (if only a
+        single filled rectangle is present) or on pin positions.
         """
 
-        x_min = y_min = x_max = y_max = None
+        # If there is only a single filled rectangle, we assume that it is the
+        # main symbol outline.
+        drawing = self.component.draw
+        filled_rects = [rect for rect in drawing['rectangles']
+                        if rect['fill'] == 'f']
+        if len(filled_rects) == 1:
+            # We now find it's center
+            rect = filled_rects[0]
+            x = (int(rect['startx']) + int(rect['endx'])) // 2
+            y = (int(rect['starty']) + int(rect['endy'])) // 2
+        else:
+            x_min = y_min = x_max = y_max = None
 
-        pins = self.component.pins
+            pins = self.component.pins
 
-        # No pins? Ignore check.
-        # This can be improved to include graphical items too...
-        if len(pins) == 0:
-            return False
+            # No pins? Ignore check.
+            # This can be improved to include graphical items too...
+            if len(pins) == 0:
+                return False
 
-        for i, p in enumerate(pins):
+            for i, p in enumerate(pins):
 
-            x = int(p['posx'])
-            y = int(p['posy'])
+                x = int(p['posx'])
+                y = int(p['posy'])
 
-            if i == 0:
-                x_min = x_max = x
-                y_min = y_max = y
-            else:
-                x_min = min(x_min, x)
-                x_max = max(x_max, x)
-                y_min = min(y_min, y)
-                y_max = max(y_max, y)
+                if i == 0:
+                    x_min = x_max = x
+                    y_min = y_max = y
+                else:
+                    x_min = min(x_min, x)
+                    x_max = max(x_max, x)
+                    y_min = min(y_min, y)
+                    y_max = max(y_max, y)
 
-        # Center point average
-        x = (x_min + x_max) / 2
-        y = (y_min + y_max) / 2
+            # Center point average
+            x = (x_min + x_max) / 2
+            y = (y_min + y_max) / 2
 
         # Right on the middle!
         if x == 0 and y == 0:


### PR DESCRIPTION
instead of center of all pins. This is done only if the symbol has a single rectangle with foreground fill.