### PR TITLE
Fix schlib/check_lib

### DIFF
--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -92,6 +92,8 @@ for libfile in libfiles:
     if len(libfiles) > 1:
         printer.purple('Library: %s' % libfile)
 
+    n_allviolations=0
+    
     for component in lib.components:
 
         #simple match
@@ -156,8 +158,10 @@ for libfile in libfiles:
         # check the number of violations
         if n_violations > 0:
             exit_code += 1
-
-    if args.fix and n_violations > 0:
+        n_allviolations=n_allviolations+n_violations
+        
+    if args.fix and n_allviolations > 0:
         lib.save()
+        printer.green("saved '{file}' with fixes for {n_violations} violations.".format(file=libfile, n_violations=n_allviolations))
 
 sys.exit(exit_code);

--- a/schlib/rules/S4_4.py
+++ b/schlib/rules/S4_4.py
@@ -111,7 +111,7 @@ class Rule(KLCRule):
             m = re.search('(\~)(.+)', pin['name'])
             if m and pin['pin_type'] == 'I':
                 if len(self.inversion_errors) == 0:
-                    self.error("Pins should not be inverted twice")
+                    self.error("Pins should not be inverted twice (with inversion-symbol on pin and overline on label)")
                 self.inversion_errors.append(pin)
                 self.errorExtra("{pin} : double inversion (overline + pin type:Inverting)".format(pin=pinString(pin)))
 

--- a/schlib/rules/S6_2.py
+++ b/schlib/rules/S6_2.py
@@ -142,7 +142,7 @@ class Rule(KLCRule):
         self.component.fields[1]['name'] = self.component.name
         # store datasheet field contents for later reuse
         if len(self.component.documentation['datasheet'])==0 and len(self.component.fields[3]['name'])>0:
-            self.component.documenttaion['datasheet']=self.component.fields[3]['name']
+            self.component.documentation['datasheet']=self.component.fields[3]['name']
             self.info( "Copying DATASHEET to DCM-file ...")
         
         self.info( "Emptying DATASHEET-field ...")

--- a/schlib/rules/S6_2.py
+++ b/schlib/rules/S6_2.py
@@ -141,9 +141,12 @@ class Rule(KLCRule):
         self.info( "Fixing VALUE-field...")
         self.component.fields[1]['name'] = self.component.name
         # store datasheet field contents for later reuse
-        if len(self.component.documentation['datasheet'])==0 and len(self.component.fields[3]['name'])>0:
-            self.component.documentation['datasheet']=self.component.fields[3]['name']
-            self.info( "Copying DATASHEET to DCM-file ...")
+        if ((not self.component.documentation['datasheet']) or len(self.component.documentation['datasheet'])==0) and (len(self.component.fields[3]['name'])>2):
+            ds=self.component.fields[3]['name']
+            if ds[0]=='"' and ds[len(ds)-1]=='"':
+                ds=ds[1:(len(ds)-1)]
+            self.component.documentation['datasheet']=ds
+            self.info( "Copying DATASHEET '{ds}' to DCM-file ...".format(ds=ds))
         
         self.info( "Emptying DATASHEET-field ...")
         self.component.fields[3]['name'] = ""

--- a/schlib/rules/S6_2.py
+++ b/schlib/rules/S6_2.py
@@ -138,7 +138,19 @@ class Rule(KLCRule):
         """
         Proceeds the fixing of the rule, if possible.
         """
-        self.info( "Fixing..")
+        self.info( "Fixing VALUE-field...")
         self.component.fields[1]['name'] = self.component.name
+        # store datasheet field contents for later reuse
+        if len(self.component.documentation['datasheet'])==0 and len(self.component.fields[3]['name'])>0:
+            self.component.documenttaion['datasheet']=self.component.fields[3]['name']
+            self.info( "Copying DATASHEET to DCM-file ...")
+        
+        self.info( "Emptying DATASHEET-field ...")
+        self.component.fields[3]['name'] = ""
 
+        self.info( "Setting default field visibilities ...")
+        self.component.fields[0]['visibility'] = "V"
+        self.component.fields[1]['visibility'] = "V"
+        self.component.fields[2]['visibility'] = "I"
+        self.component.fields[3]['visibility'] = "I"
         self.recheck()


### PR DESCRIPTION
This summarizes three smaller bugfixes/improvements. the first one is a major bug, the rest is only minor stuff:
- **schlib/checklib.py did not save the library-file after a --fix-run in some cases (because a global counter was reset to 0)**
- improved error description in S4.4 
- S6.2: improved fixes to KiCAD fields (visibility, copy datasheet link from field to DCM ...)