### PR TITLE
demote warnings for off-center symbols with less than 50mil off-center to simple info-output

### DIFF
--- a/schlib/rules/S3_1.py
+++ b/schlib/rules/S3_1.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from rules.rule import *
+import math
 
 class Rule(KLCRule):
     """
@@ -46,6 +47,9 @@ class Rule(KLCRule):
         # Right on the middle!
         if x == 0 and y == 0:
             return False
+        elif math.fabs(x)<=50 and math.fabs(y)<=50:
+            self.info("Symbol slightly off-center")
+            self.info("  Center calculated @ ({x}, {y})".format(x=x, y=y))
         else:
             self.warning("Symbol not centered on origin")
             self.warningExtra("Center calculated @ ({x}, {y})".format(x=x, y=y))


### PR DESCRIPTION
Often symbols are only 25 or 50mil of-center. In these cases the script now only outputs info ... no longer a real warning ... I would even say we can ignore these cases altogether and give no output at all ... What doy ou think?

JAN