### PR TITLE
F9.1 crashes in some cases

### DIFF
--- a/pcb/rules/F9_1.py
+++ b/pcb/rules/F9_1.py
@@ -27,12 +27,13 @@ class Rule(KLCRule):
             return True
 
         illegal = [',', ';', ':']
-
+        mod.tags=str(mod.tags)
         #check for illegal tags
-        for char in illegal:
-            if char in mod.tags:
-                self.error("Tags contain illegal character: ('{c}')".format(c=char))
-                error = True
+        if len(mod.tags)>1:
+            for char in illegal:
+                if char in mod.tags:
+                    self.error("Tags contain illegal character: ('{c}')".format(c=char))
+                    error = True
 
         return error
 


### PR DESCRIPTION
- F9.1 crashed with an exception, when a tag was a number only, as it is automatically converted to an int by the file-reader. This fix converts anything to a string first and checks the result then.
- this was found in this PR: https://github.com/KiCad/kicad-footprints/pull/236#issuecomment-356581010 & https://travis-ci.org/KiCad/kicad-footprints/builds/326992359?utm_source=github_status&utm_medium=notification