### PR TITLE
added heuristics to recognize "small" symbols (resistor, transistor, diodes, ...) and modify KLC-requirements accordingly

### DIFF
--- a/schlib/rules/S3_3.py
+++ b/schlib/rules/S3_3.py
@@ -25,11 +25,20 @@ class Rule(KLCRule):
         self.n_rectangles = len(self.component.draw['rectangles'])
         if self.n_rectangles != 1: return False
 
-        if (self.component.draw['rectangles'][0]['thickness'] != '10'):
-            self.error("Component line is thickness {0}mil, recommended is {1}mil".format(self.component.draw['rectangles'][0]['thickness'],10))
-            rectangle_need_fix = True
+        if self.component.isSmallComponentHeuristics():
+            if (self.component.draw['rectangles'][0]['thickness'] != '10'):
+                self.warning("Component outline is thickness {0}mil, recommended is {1}mil for standard symbol".format(self.component.draw['rectangles'][0]['thickness'],10))
+                self.warningExtra("exceptions are allowed for small symbols like resistor, transistor, ...")
+                rectangle_need_fix = False
+        else:
+            if (self.component.draw['rectangles'][0]['thickness'] != '10'):
+                self.error("Component outline is thickness {0}mil, recommended is {1}mil".format(self.component.draw['rectangles'][0]['thickness'],10))
+                rectangle_need_fix = True
+
         if (self.component.draw['rectangles'][0]['fill'] != 'f'):
             self.warning("Component background is filled with {0} color, recommended is filling with {1} color".format(backgroundFillToStr(self.component.draw['rectangles'][0]['fill']),backgroundFillToStr('f')))
+            if self.component.isSmallComponentHeuristics():
+                self.warningExtra("exceptions are allowed for small symbols like resistor, transistor, ...")
             rectangle_need_fix = True
 
         return True if rectangle_need_fix else False

--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -301,6 +301,24 @@ class Component(object):
     def isGraphicSymbol(self):
         return self.isNonBOMSymbol() and len(self.pins)==0
 
+    # heuristics, which tries to determine whether this is a "small" component (resistor, capacitor, LED, diode, transistor, ...)
+    def isSmallComponentHeuristics(self):
+        if len(self.pins)<=2:
+            return True;
+
+        # If there is only a single filled rectangle, we assume that it is the
+        # main symbol outline.
+        drawing = self.draw
+        filled_rects = [rect for rect in drawing['rectangles']
+                        if rect['fill'] == 'f']
+        
+        # if there is no filled rectangle as symbol outline and we have 3 or 4 pins, we assume this 
+        # is a small symbol
+        if len(self.pins)>=3 and len(self.pins)<=4 and len(filled_rects) == 0:
+            return True;
+        
+        return False;
+
 
 
 


### PR DESCRIPTION
This PR adds a heuristics to detect "small" components (e.g. resistors, diodes, transistors), currently with these rules:
1. 2-pins are always small components (most ICs have more pins)
2. 3 or 4 pins and no surrounding symbol outline that is filled with "BACKGROUND" (typically used for symbol outlines according to KLC)

When this heuristics thinks it's a small component I modify a few KLC rules:
- S3.3 outputs only a warning if it does not find a surrounding rectangle with 10mil+BACKGROUND-filling, instead of an error (e.g. we don't want errors with resistors that actually might have such a rectangle)
- S4.1 relaxes its conditions (usually: require 100mil grid, error for pins <50mil and warning <100mil) to require 50mil-grid, error for pin-lengths <25mil and a warning for pin-lengths <50mil

This way we get rid of several warnings/errors e.g. in Transistor_*.lib, Dveice.Lib, ... but retain errors for e.g. 3-pin temperature-sensors that are drawn with a rectangle (I tested on MAX31820)