### PR TITLE
fixes rule-check for S3.2 (label/name fields of pins)

### DIFF
--- a/schlib/rules/S3_2.py
+++ b/schlib/rules/S3_2.py
@@ -7,7 +7,7 @@ class Rule(KLCRule):
     Create the methods check and fix to use with the kicad lib files.
     """
     def __init__(self, component):
-        super(Rule, self).__init__(component, 'Text fields should use common size of 50mils')
+        super(Rule, self).__init__(component, 'Text fields should use common size of 50mils, but labels and numbers may use text size as low as 20mil if required')
 
     def check(self):
         """
@@ -42,11 +42,14 @@ class Rule(KLCRule):
             name_text_size = int(pin['name_text_size'])
             num_text_size = int(pin['num_text_size'])
 
-            if (name_text_size < 20) or (name_text_size > 50) or (num_text_size != 50):
+            if (name_text_size < 20) or (name_text_size > 50) or (num_text_size < 20) or (num_text_size > 50):
                 self.violating_pins.append(pin)
                 self.error(' - Pin {0} ({1}), text size {2}, number size {3}'.format(pin['name'], pin['num'], pin['name_text_size'], pin['num_text_size']))
-            elif name_text_size != 50:
-                self.warning("Pin name text size should be 50mils")
+            else:
+                if name_text_size != 50:
+                    self.warning("Pin name text size should be 50mils (or 20...50mils if required by the symbol geometry)")
+                if num_text_size != 50:
+                    self.warning("Pin number text size should be 50mils (or 20...50mils if required by the symbol geometry)")
 
         if (len(self.violating_fields) > 0 or
             len(self.violating_pins) > 0):


### PR DESCRIPTION
- fixes rule-check for S3.2 to also correctly check number text size for the range 20..50mil 
- plus: added improved output on errors/warnings, hinting at the allowed range
- gets check more in line with rule http://kicad-pcb.org/libraries/klc/S3.2/