### PR TITLE
Swap name_text_size and num_text_size

### DIFF
--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -130,7 +130,7 @@ class Component(object):
     _POLY_KEYS = ['point_count','unit','convert','thickness','points','fill']
     _RECT_KEYS = ['startx','starty','endx','endy','unit','convert','thickness','fill']
     _TEXT_KEYS = ['direction','posx','posy','text_size','text_type','unit','convert','text', 'italic', 'bold', 'hjustify', 'vjustify']
-    _PIN_KEYS = ['name','num','posx','posy','length','direction','name_text_size','num_text_size','unit','convert','electrical_type','pin_type']
+    _PIN_KEYS = ['name','num','posx','posy','length','direction','num_text_size','name_text_size','unit','convert','electrical_type','pin_type']
 
     _DRAW_KEYS = {'A':_ARC_KEYS, 'C':_CIRCLE_KEYS, 'P':_POLY_KEYS, 'S':_RECT_KEYS, 'T':_TEXT_KEYS, 'X':_PIN_KEYS}
     # _DRAW_ELEMS = {'arcs':'A', 'circles':'C', 'polylines':'P', 'rectangles':'S', 'texts':'T', 'pins':'X'}


### PR DESCRIPTION
The order of num_text_size and name_text_size in _PIN_KEYS is wrong. If a symbol violates S3.2, checklib.py outputs the opposite warning.

Example:
For a pin with a 50mil number and 40mil name:
```
X VDD 4 0 400 100 D 50 40 1 1 W
```
You get this:
```
Pin number text size should be 50mils (or 20...50mils if required by the symbol geometry)
```

