### PR TITLE
Add support for the new offset field for model placement.

### DIFF
--- a/pcb/kicad_mod.py
+++ b/pcb/kicad_mod.py
@@ -430,7 +430,10 @@ class KicadMod(object):
             model_dict = {'file':model[1]}
 
             # position
-            xyz = self._getArray(self._getArray(model, 'at'), 'xyz')[0]
+            offset = self._getArray(model, 'at')
+            if len(offset) < 1:
+                offset = self._getArray(model, 'offset')
+            xyz = self._getArray(offset, 'xyz')[0]
             model_dict['pos'] = {'x':xyz[1], 'y':xyz[2], 'z':xyz[3]}
 
             # scale


### PR DESCRIPTION
Newer versions of kicad use the metric 'offset' keyword instead of the imperial 'at' to communicate 3d model offset. This commit does ensure that such newer files can be parsed.

While looking at this i noticed that neither scale, rotation nor offset are checked in any rule. (mention for requirements for rotation and offset are also absent from the KLC rule http://kicad-pcb.org/libraries/klc/F9.3/)