### PR TITLE
Add additional checks and fix options for 3d model settigns.

### DIFF
--- a/pcb/rules/F9_3.py
+++ b/pcb/rules/F9_3.py
@@ -10,17 +10,54 @@ class Rule(KLCRule):
     Create the methods check and fix to use with the kicad_mod files.
     """
     def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, '3D model reference')
+        super(Rule, self).__init__(module, args, '3D model settings')
 
     def checkModel(self, model):
 
         error = False
 
+        self.model3D_wrongOffset = False
+        self.model3D_wrongRotation = False
+        self.model3D_wrongScale = False
+
+        if model['pos']['x'] != 0 or\
+                model['pos']['y'] != 0 or\
+                model['pos']['z'] != 0:
+            error = True
+            self.model3D_wrongOffset = True
+
+            self.error("Model offset different from "\
+                "{{'x': 0, 'y': 0, 'z': 0}}. "\
+                "Found {{'x': {o[x]:}, 'y': {o[y]:}, 'z': {o[z]:}}}"\
+                .format(o=model['pos']))
+
+        if model['rotate']['x'] != 0 or\
+                model['rotate']['y'] != 0 or\
+                model['rotate']['z'] != 0:
+            error = True
+            self.model3D_wrongRotation = True
+
+            self.error("Model rotation different from "\
+                "{{'x': 0, 'y': 0, 'z': 0}}. "\
+                "Found {{'x': {r[x]:}, 'y': {r[y]:}, 'z': {r[z]:}}}"\
+                .format(r=model['rotate']))
+
+        if model['scale']['x'] != 1 or\
+                model['scale']['y'] != 1 or\
+                model['scale']['z'] != 1:
+            error = True
+            self.model3D_wrongScale = True
+
+            self.error("Model scale different from "\
+                "{{'x': 1, 'y': 1, 'z': 1}}. "\
+                "Found {{'x': {s[x]:}, 'y': {s[y]:}, 'z': {s[z]:}}}"\
+                .format(s=model['scale']))
+
         # Allowed model types
         extensions = ["step", "stp", "wrl"]
 
         model = model['file']
-        
+
         self.model3D_missingSYSMOD = False
         self.model3D_wrongLib = False
         self.model3D_wrongName = False
@@ -95,7 +132,7 @@ class Rule(KLCRule):
             * model_file
         """
         module = self.module
-        
+
         module_dir = os.path.split(os.path.dirname(os.path.realpath(module.filename)))[-1]
         self.module_dir = os.path.splitext(module_dir)
 
@@ -106,8 +143,8 @@ class Rule(KLCRule):
         self.model3D_expectedDir = SYSMOD_PREFIX+fp_dir+'/';
         self.model3D_expectedName = fp_name+'.wrl';
         self.model3D_expectedFullPath = self.model3D_expectedDir+self.model3D_expectedName;
-        
-        
+
+
 
         if len(models) == 0:
             # Warning msg
@@ -139,7 +176,7 @@ class Rule(KLCRule):
         Proceeds the fixing of the rule, if possible.
         """
         module = self.module
-        
+
         # ensure all variables are set correctly
         if self.no3DModel:
             # model (default)
@@ -150,17 +187,22 @@ class Rule(KLCRule):
             module.models.append(model_dict)
             self.info("added default model '{model}' to footprint.".format(model=self.model3D_expectedFullPath))
             return
-        elif not self.tooMany3DModel and (self.model3D_missingSYSMOD or self.model3D_wrongLib or self.model3D_wrongName):
-            if self.args.fixmore:
-                # model (default)
-                oldpath=module.models[0]['file']
-                module.models[0]['file']=self.model3D_expectedFullPath
-                self.info("fixed model path from '{oldmodel}' to '{model}'.".format(oldmodel=oldpath, model=self.model3D_expectedFullPath))
-                return
-            else:
+
+        if self.model3D_wrongOffset or self.model3D_wrongRotation or\
+                self.model3D_wrongScale:
+            module.models[0]['pos'] = {'x':0, 'y':0, 'z':0}
+            module.models[0]['scale'] = {'x':1, 'y':1, 'z':1}
+            module.models[0]['rotate'] = {'x':0, 'y':0, 'z':0}
+            self.info("Fixed 3d model settings (offset, scale and/or rotation).")
+            return
+
+        if not self.tooMany3DModel and (self.model3D_missingSYSMOD or self.model3D_wrongLib or self.model3D_wrongName):
+            if not self.args.fixmore:
                 self.info("Fix not supported by --fix, use --fixmore to fix this!")
+                print("hello")
                 return
-                
+            print("wtf?!")
+
         self.info("Fix not supported")
         return
 
@@ -169,7 +211,7 @@ class Rule(KLCRule):
         Proceeds the additional fixing of the rule, if possible and if --fixmore is provided as command-line argument.
         """
         module = self.module
-        
+
         # ensure all variables are set correctly
         if not self.tooMany3DModel and (self.model3D_missingSYSMOD or self.model3D_wrongLib or self.model3D_wrongName):
             # model (default)
@@ -177,6 +219,6 @@ class Rule(KLCRule):
             module.models[0]['file']=self.model3D_expectedFullPath
             self.info("fixed model path from '{oldmodel}' to '{model}'.".format(oldmodel=oldpath, model=self.model3D_expectedFullPath))
             return
-                
+
         self.info("FixMore not supported")
         return

--- a/pcb/rules/F9_3.py
+++ b/pcb/rules/F9_3.py
@@ -199,9 +199,7 @@ class Rule(KLCRule):
         if not self.tooMany3DModel and (self.model3D_missingSYSMOD or self.model3D_wrongLib or self.model3D_wrongName):
             if not self.args.fixmore:
                 self.info("Fix not supported by --fix, use --fixmore to fix this!")
-                print("hello")
                 return
-            print("wtf?!")
 
         self.info("Fix not supported")
         return

--- a/pcb/rules/F9_3.py
+++ b/pcb/rules/F9_3.py
@@ -26,7 +26,7 @@ class Rule(KLCRule):
             error = True
             self.model3D_wrongOffset = True
 
-            self.error("Model offset different from "\
+            self.error("3D model offset different from "\
                 "{{'x': 0, 'y': 0, 'z': 0}}. "\
                 "Found {{'x': {o[x]:}, 'y': {o[y]:}, 'z': {o[z]:}}}"\
                 .format(o=model['pos']))
@@ -37,7 +37,7 @@ class Rule(KLCRule):
             error = True
             self.model3D_wrongRotation = True
 
-            self.error("Model rotation different from "\
+            self.error("3D model rotation different from "\
                 "{{'x': 0, 'y': 0, 'z': 0}}. "\
                 "Found {{'x': {r[x]:}, 'y': {r[y]:}, 'z': {r[z]:}}}"\
                 .format(r=model['rotate']))
@@ -48,7 +48,7 @@ class Rule(KLCRule):
             error = True
             self.model3D_wrongScale = True
 
-            self.error("Model scale different from "\
+            self.error("3D model scale different from "\
                 "{{'x': 1, 'y': 1, 'z': 1}}. "\
                 "Found {{'x': {s[x]:}, 'y': {s[y]:}, 'z': {s[z]:}}}"\
                 .format(s=model['scale']))

--- a/pcb/rules/F9_3.py
+++ b/pcb/rules/F9_3.py
@@ -26,7 +26,7 @@ class Rule(KLCRule):
             error = True
             self.model3D_wrongOffset = True
 
-            self.error("3D model offset different from "\
+            self.error("3D model offset is not "\
                 "{{'x': 0, 'y': 0, 'z': 0}}. "\
                 "Found {{'x': {o[x]:}, 'y': {o[y]:}, 'z': {o[z]:}}}"\
                 .format(o=model['pos']))
@@ -37,7 +37,7 @@ class Rule(KLCRule):
             error = True
             self.model3D_wrongRotation = True
 
-            self.error("3D model rotation different from "\
+            self.error("3D model rotation is not "\
                 "{{'x': 0, 'y': 0, 'z': 0}}. "\
                 "Found {{'x': {r[x]:}, 'y': {r[y]:}, 'z': {r[z]:}}}"\
                 .format(r=model['rotate']))
@@ -48,7 +48,7 @@ class Rule(KLCRule):
             error = True
             self.model3D_wrongScale = True
 
-            self.error("3D model scale different from "\
+            self.error("3D model scale is not "\
                 "{{'x': 1, 'y': 1, 'z': 1}}. "\
                 "Found {{'x': {s[x]:}, 'y': {s[y]:}, 'z': {s[z]:}}}"\
                 .format(s=model['scale']))
@@ -198,7 +198,7 @@ class Rule(KLCRule):
 
         if not self.tooMany3DModel and (self.model3D_missingSYSMOD or self.model3D_wrongLib or self.model3D_wrongName):
             if not self.args.fixmore:
-                self.info("Fix not supported by --fix, use --fixmore to fix this!")
+                self.info("Use --fixmore instead of --fix to correct the 3D model settings!")
                 return
 
         self.info("Fix not supported")


### PR DESCRIPTION
While creating the fix for the new offset property (PR https://github.com/KiCad/kicad-library-utils/pull/215) i noticed that there are no checks for 3d model scale, rotation and offset.
This PR does add a check and fix option for this.

I also removed duplicate fixmore code. (I assume in the past there was no separate fixmore member function but that was handled as part of the fix function.)