### PR TITLE
Don't accept STEP files

### DIFF
--- a/pcb/rules/F9_3.py
+++ b/pcb/rules/F9_3.py
@@ -54,7 +54,7 @@ class Rule(KLCRule):
                 .format(s=model['scale']))
 
         # Allowed model types
-        extensions = ["step", "stp", "wrl"]
+        extensions = ["wrl"]
 
         model = model['file']
 
@@ -87,7 +87,7 @@ class Rule(KLCRule):
         model_ext = fn[-1]
 
         if not model_ext.lower() in extensions:
-            self.error("Model '{mod}' is incompatible format (must be STEP or WRL file)".format(mod=model))
+            self.error("Model '{mod}' is incompatible format (must be WRL file)".format(mod=model))
             self.model3D_wrongFiletype = True
             self.needsFixMore = True
             return True


### PR DESCRIPTION
KLC F9.3 currently says that only .wrl files are allowed for 3D model associations.  This PR updates the checking script to not accept .step files.