### PR TITLE
Correctly read footprint's clearance setting

### DIFF
--- a/pcb/kicad_mod.py
+++ b/pcb/kicad_mod.py
@@ -99,7 +99,7 @@ class KicadMod(object):
         self.autoplace_cost180 = self._getValue('autoplace_cost180', 0, 2)
 
         # global footprint clearance settings
-        self.clearance = self._getValue('clearance', 0)
+        self.clearance = self._getValue('clearance', 0, 2)
         self.solder_mask_margin = self._getValue('solder_mask_margin', 0, 2)
         self.solder_paste_margin = self._getValue('solder_paste_margin', 0, 2)
         self.solder_paste_ratio = self._getValue('solder_paste_ratio', 0, 2)
@@ -145,14 +145,15 @@ class KicadMod(object):
     def _getArray(self, data, value, result=None, level=0, max_level = None):
         if result is None: result = []
 
-        level += 1
-
         if max_level is not None and max_level <= level:
             return result
 
+        level += 1
+
         for i in data:
             if type(i) == type([]):
-                self._getArray(i, value, result, level=level)
+                self._getArray(i, value, result, level=level,
+                        max_level=max_level)
             else:
                 if i == value:
                     result.append(data)


### PR DESCRIPTION
There was a problem before where a KicadMod's clearance attribute was set to that of a pad (or the clearance option of a custom shaped pad) if the footprint itself didn't have a clearance value set.  This ultimately was caused by improper recursion depth limiting in KicadMod._getArray.

This PR fixes the problem, making the attributes read from only the top level of the kicad_mod's module object.

The fix causes the script to no longer check if any individual pad's clearance values are non-zero.  This was done before, but by my understanding of the code it was mostly accidental.  If we want to continue to check for that, it would be best to write code specifically to look for it, so that more helpful messages can be printed including e.g. the number of the offending pad.

Please let me know if you'd like this additional check to be done before this is merged, as I'd be happy to implement it.  I'm not totally clear on whether this additional check should be part of the test for rule [F9.2](http://kicad-pcb.org/libraries/klc/F9.2/) or a new test for [F4.6](http://kicad-pcb.org/libraries/klc/F4.6/), so please let me know that too if I am to implement it.

Fixes #221.