### PR TITLE
MPN and Datasheet assingment tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,44 @@ KiCad utilities
 
 **update_footprints.py**: This script updates the footprints fields of sch files using a csv as input.
 
-**assign_mpns.py**: This script updates the MPN and Datasheet fields of sch files using a json as input.
+**assign_mpns.py**: This script updates the MPN and Datasheet fields of sch files using a json lookup table as input.
+The json file may look like this
+```json
+{
+    "C": [
+        {
+            "Value"             : "100n",
+            "Footprint"         : "Capacitors_SMD:C_0402",
+            "Tolerance"         : "5%",
+            "MPN"               : "12345",
+            "Datasheet"         : "https://www.url.tld/12345.pdf"
+        },
+        {
+            "Value"             : "1u",
+            "Footprint"         : "Resistors_SMD:R_0402",
+            "Tolerance"         : "10%",
+            "MPN"               : "abcde",
+            "Datasheet"         : "https://www.url.tld/abcde.pdf"
+        }
+    ],
+    "R": [
+        {
+            "Value"             : "100",
+            "Footprint"         : "Capacitors_SMD:C_0402",
+            "Tolerance"         : "5%",
+            "MPN"               : "67890",
+            "Datasheet"         : "https://www.url.tld/67890.pdf"
+        },
+        {
+            "Value"             : "1k",
+            "Footprint"         : "Resistors_SMD:R_0402",
+            "Tolerance"         : "10%",
+            "MPN"               : "fghij",
+            "Datasheet"         : "https://www.url.tld/fghij.pdf"
+        }
+    ]
+}
+```
 
 ## pcb directory
 
@@ -77,7 +114,21 @@ How to use
     # run the following command to see other options
     ./add_part_number.py -h
 
+## Assigning Manufacturer Part Numbers (MPNs) and Datasheet Links
 
+    # first get into sch directory
+    cd sch
+    
+    # use the following command to add the MPN and Datasheet field using the passed json lookup table file
+    # the lookup table is a dict of lists of dicts
+    # the key for each list is the acronym for the part category
+    # e.g. "R" for resistors, "C" for capacitors, "IC" for integrated circuits
+    # the behaviour is search for a complete matching ditch is the correct list for each part
+    ./assign_mpns.py -s path_to_sch_file -l path_to_json_lut
+    
+    # run the following command to see the help
+    ./assign_mpns.py -h
+    
 ## Footprint Checker
 
     # first get into pcb directory

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ KiCad utilities
 
 **update_footprints.py**: This script updates the footprints fields of sch files using a csv as input.
 
+**assign_mpns.py**: This script updates the MPN and Datasheet fields of sch files using a json as input.
+
 ## pcb directory
 
 **kicad_mod.py**: A python class to handle KiCad footprint files, as know as kicad_mod.

--- a/sch/assign_mpns.py
+++ b/sch/assign_mpns.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from argparse import ArgumentParser
+from json import load
+from errno import ENOENT, EINVAL
+from re import compile as regex
+from sch import *
+
+def parse_arguments():
+    parser = ArgumentParser(description='Tool to assign MPNs to symbols in a KiCAD schematic')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-v",  "--verbose",     action = "store_true",        help = 'doesn\'t do anything ATM')
+    parser.add_argument('-s', "--schematic",   type = str, required=True,    help='path to .sch file')
+    parser.add_argument('-l', "--lookuptable", type = str, required=True,    help='path to mpn lookup table')
+    args = parser.parse_args()
+    return args
+
+def read_schematic(path):
+    try:
+        return Schematic(path)
+    except FileNotFoundError as fnfe:
+        print(fnfe)
+        print("Could not find schematic file")
+        exit(ENOENT)
+
+def read_lut(path):
+    try:
+        return load(open(path, 'r'))
+    except FileNotFoundError as fnfe:
+        print(fnfe)
+        print("Could not find lookup table file")
+        exit(ENOENT)
+    except json.decoder.JSONDecodeError as jsone:
+        print(jsone)
+        print("Could not read lookup table file")
+        exit(EINVAL)
+
+def main():
+    args     = parse_arguments()
+    sch      = read_schematic(args.schematic)
+    part_lut = read_lut(args.lookuptable)
+    cat_expr = regex('[a-zA-Z]+')
+
+    for component in sch.components:
+        if '#PWR' in component.fields[0]['ref'] or\
+           'PWR_FLAG' in component.fields[1]['ref']:
+            continue
+
+        Reference = component.fields[0]["ref"].replace('"', '')
+        category  = cat_expr.match(Reference).group()
+        datasheet_field = component.fields[3]
+        mpn_field = None
+
+        # Buildtuple of identifying properties
+        sch_tuple = {
+            "Value"     : component.fields[1]["ref"].replace('"', ''),
+            "Footprint" : component.fields[2]["ref"].replace('"', ''),
+        }
+        for field in component.fields[4:]:
+            key   = field["name"].replace('"', '')
+            value = field["ref"].replace('"', '')
+            if key != "MPN":
+                sch_tuple.update({key : value})
+            else:
+                mpn_field = field
+
+        if not mpn_field:
+            mpn_field = component.addField({'name': '"MPN"', 'ref': '""'})
+
+        # Try to match tuple
+        if category in part_lut:
+            found = False
+            for part in part_lut[category]:
+                part_tuple = part.copy()
+                try:
+                    part_tuple.pop("MPN") 
+                    part_tuple.pop("Datasheet")
+                except KeyError as ke:
+                    print("{} missing for {}: {}".format(ke, category, part))
+                    pass
+                # In case of match, assign MPN and Datasheet
+                if(part_tuple == sch_tuple):
+                    found = True
+                    mpn_field["ref"] = "\"{}\"".format(part["MPN"])
+                    datasheet_field["ref"] = "\"{}\"".format(part["Datasheet"])
+                    break
+            if not found:
+                print("No part found for {}: {}".format(Reference, sch_tuple))
+        else:
+            print("Category {} not found".format(category))
+    sch.save()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I wrote a python script that allow the fast addition/change of the MPN field of every component of a schematic. The goal is to enable fast and consistent changes. This enables for example the switch from one part supplier to another without manually changing the schemaic.

The script iterates over all components of a schematic and tries to find 100% matches in the supplied lookup table json file. A lookup table might look like this:
```
{
    "C": [
        {
            "Value"             : "100n",
            "Footprint"         : "Capacitors_SMD:C_0402",
            "Tolerance"         : "5%",
            "MPN"               : "12345",
            "Datasheet"         : "https://www.url.tld/12345.pdf"
        },
        {
            "Value"             : "1u",
            "Footprint"         : "Resistors_SMD:R_0402",
            "Tolerance"         : "10%",
            "MPN"               : "abcde",
            "Datasheet"         : "https://www.url.tld/abcde.pdf"
        }
    ],
    "R": [
        {
            "Value"             : "100",
            "Footprint"         : "Capacitors_SMD:C_0402",
            "Tolerance"         : "5%",
            "MPN"               : "67890",
            "Datasheet"         : "https://www.url.tld/67890.pdf"
        },
        {
            "Value"             : "1k",
            "Footprint"         : "Resistors_SMD:R_0402",
            "Tolerance"         : "10%",
            "MPN"               : "fghij",
            "Datasheet"         : "https://www.url.tld/fghij.pdf"
        }
    ]
}
```