### PR TITLE
Fix description of rule S3.1

### DIFF
--- a/schlib/rules/S3_1.py
+++ b/schlib/rules/S3_1.py
@@ -8,7 +8,7 @@ class Rule(KLCRule):
     Create the methods check and fix to use with the kicad lib files.
     """
     def __init__(self, component):
-        super(Rule, self).__init__(component, 'Origin is be centered on the middle of the symbol')
+        super(Rule, self).__init__(component, 'Origin is centered on the middle of the symbol')
 
     def check(self):
         """


### PR DESCRIPTION
Somehow the word "be" crept in where it doesn't belong.  This fixes it.

@evanshultz would you mind taking a look, like I did for your similar PR a couple days ago? 🙂