### PR TITLE
Minor reorganization of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ KiCad utilities
 
 **checklib.py**: Script for checking [KLC][] compliance of schematic symbol libraries.
 
-**schlib.py**: A Python module for parsing KiCad's Schematic Libraries Files Format.
+**schlib.py**: A Python module for parsing KiCad's schematic library file format.
 
 **test_schlib.sh**: A shell script used to validate the generation of files of the schlib module.
 
-**fix-pins.py**: A script created to help adapt existing library files to the [KiCad Library Convention][KLC] by testing some cases of x/y "wrong" pin positions and trying to fix them. The description of the cases are explained in the head of the script file.
+**fix-pins.py**: A script created to help adapt existing library files to the [KiCad Library Convention][KLC] by testing some cases of x/y "wrong" pin positions and trying to fix them. The description of the cases are explained in the header of the script file.
 
 **move_part.py**: Script to move components between libraries.
 
@@ -18,21 +18,21 @@ KiCad utilities
 
 ## sch directory
 
-**sch.py**: A Python module for parsing KiCad's Schematic Files Format.
+**sch.py**: A Python module for parsing KiCad's schematic file format.
 
 **test_sch.sh**: A shell script used to validate the generation of files of the sch module.
 
 **add_part_number.py**: This script is used to add/edit part number fields in the schematic files.
 
-**update_footprints.py**: This script updates the footprint fields of sch files using a csv file as input.
+**update_footprints.py**: This script updates the footprint fields of `.sch` files using a `.csv` file as input.
 
 ## pcb directory
 
 **check_kicad_mod.py**: Script for checking [KLC][] compliance of footprint files.
 
-**kicad_mod.py**: A Python module for working with KiCad footprint files.
+**kicad_mod.py**: A Python module for loading, editing, and saving KiCad footprint files.
 
-**check_3d_coverage.py**: Script for checking which KiCad footprint files have references to 3D models that exist in the associated `3dshapes` folder in the KiCad library. It also shows unused 3D model files.
+**check_3d_coverage.py**: Script for checking which KiCad footprints in a `.pretty` library have 3D models. It also shows unused 3D model files.
 
 [KLC]: http://kicad-pcb.org/libraries/klc/
 

--- a/README.md
+++ b/README.md
@@ -4,42 +4,37 @@ KiCad utilities
 
 ## schlib directory
 
-**schlib.py**: A python class to parse Schematic Libraries Files Format of the KiCad.
+**checklib.py**: Script for checking [KLC][] compliance of schematic symbol libraries.
 
+**schlib.py**: A Python module for parsing KiCad's Schematic Libraries Files Format.
 
-**checklib.py**: Such script invokes each checkrule script testing the requested libraries.
+**test_schlib.sh**: A shell script used to validate the generation of files of the schlib module.
 
-
-**checkrule3_x.py**: Each checkrule script checks your correspondent rule and prints out a report informing what is in disagreement with the [KiCad Library Convention](https://github.com/KiCad/kicad-library/wiki/Kicad-Library-Convention).
-
-
-**fix-pins.py**: Such script was created in order to help the adaptation of the already existing library files to the KiCad Library Convention. It tests some cases of x/y "wrong" pins positions and try to fix them if they pass in the checking of some prerequisites. The description of the cases are explained in the head of the script file.
-
-**test_schlib.sh**: A shell script used to validate the generation of files of the schlib class.
+**fix-pins.py**: A script created to help adapt existing library files to the [KiCad Library Convention][KLC] by testing some cases of x/y "wrong" pin positions and trying to fix them. The description of the cases are explained in the head of the script file.
 
 **move_part.py**: Script to move components between libraries.
 
-**autogen/stm32**: Automatic STM32 library generation from pin files provided by ST. Detailed information can be found in **autogen/stm32/README.md**
+**autogen/stm32/**: Automatic STM32 library generation from pin files provided by ST. Detailed information can be found in [autogen/stm32/README.md](schlib/autogen/stm32/README.md)
 
 ## sch directory
 
-**sch.py**: A python class to parse Schematic Files Format of the KiCad.
+**sch.py**: A Python module for parsing KiCad's Schematic Files Format.
 
-**test_sch.sh**: A shell script used to validate the generation of files of the sch class.
+**test_sch.sh**: A shell script used to validate the generation of files of the sch module.
 
-**add_part_number.py**: This script is used to add/edit part numbers fields in the schematic files.
+**add_part_number.py**: This script is used to add/edit part number fields in the schematic files.
 
-**update_footprints.py**: This script updates the footprints fields of sch files using a csv as input.
+**update_footprints.py**: This script updates the footprint fields of sch files using a csv file as input.
 
 ## pcb directory
 
-**kicad_mod.py**: A python class to handle KiCad footprint files, as know as kicad_mod.
+**check_kicad_mod.py**: Script for checking [KLC][] compliance of footprint files.
 
-**check_kicad_mod.py**: Such script invokes each checkrule script testing the requested module file.
+**kicad_mod.py**: A Python module for working with KiCad footprint files.
 
-**checkruleX_Y.py**: Each checkrule script checks your correspondent rule and prints out a report informing what is in disagreement with the [KiCad Library Convention](https://github.com/KiCad/kicad-library/wiki/Kicad-Library-Convention).
+**check_3d_coverage.py**: Script for checking which KiCad footprint files have references to 3D models that exist in the associated `3dshapes` folder in the KiCad library. It also shows unused 3D model files.
 
-**check_3d_coverage.py**: This script checks which KiCad footprint files have references to 3D models that exist in the associated `3dshapes` folder in the KiCad library. It also shows unused 3D model files.
+[KLC]: http://kicad-pcb.org/libraries/klc/
 
 How to use
 ==========

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ KiCad utilities
 
 **move_part.py**: Script to move components between libraries.
 
-**autogen/stm32/**: Automatic STM32 library generation from pin files provided by ST. Detailed information can be found in [autogen/stm32/README.md](schlib/autogen/stm32/README.md)
+**autogen/**: Scripts for automatically generating schematic symbol libraries.
 
 ## sch directory
 


### PR DESCRIPTION
This PR fixes some minor grammatical errors in the README's descriptions of the various scripts.  A few outdated entries are removed.  It also rearranges the listings to put the most commonly used script for each directory first.

Whoops, I accidentally put this branch directly in the main repository.  I'll delete the branch once this PR is closed.