### PR TITLE
Give a warning for pin offset > 20 mil

### DIFF
--- a/schlib/rules/S3_6.py
+++ b/schlib/rules/S3_6.py
@@ -32,8 +32,7 @@ class Rule(KLCRule):
         """
         Proceeds the fixing of the rule, if possible.
         """
-        self.info("Fixing...")
-        self.component.draw['rectangles'][0]['thickness'] = '10'
-        self.component.draw['rectangles'][0]['fill'] = 'f'
+        self.info("Fixing, assuming typical symbol geometry...")
+        self.component.definition['text_offset'] = '20'
 
         self.recheck()

--- a/schlib/rules/S3_6.py
+++ b/schlib/rules/S3_6.py
@@ -21,6 +21,10 @@ class Rule(KLCRule):
             self.warning("Pin offset ouside allowed range")
             self.warningExtra("Pin offset ({o}) should not be below 20mils".format(o=offset))
             return True
+        elif offset > 20:
+            self.info("Pin offset is not preferred value")
+            self.info("  Pin offset ({o}) should be 20mils unless required by"
+                    " symbol geometry".format(o=offset))
 
         return False
 

--- a/schlib/rules/S3_6.py
+++ b/schlib/rules/S3_6.py
@@ -18,7 +18,7 @@ class Rule(KLCRule):
             self.errorExtra("Pin offset ({o}) must not be above 50mils".format(o=offset))
             return True
         elif offset < 20:
-            self.warning("Pin offset ouside allowed range")
+            self.warning("Pin offset outside allowed range")
             self.warningExtra("Pin offset ({o}) should not be below 20mils".format(o=offset))
             return True
         elif offset > 20:

--- a/schlib/rules/S3_6.py
+++ b/schlib/rules/S3_6.py
@@ -22,9 +22,9 @@ class Rule(KLCRule):
             self.warningExtra("Pin offset ({o}) should not be below 20mils".format(o=offset))
             return True
         elif offset > 20:
-            self.info("Pin offset is not preferred value")
-            self.info("  Pin offset ({o}) should be 20mils unless required by"
-                    " symbol geometry".format(o=offset))
+            self.warning("Pin offset is not preferred value")
+            self.warningExtra("Pin offset ({o}) should be 20mils unless"
+                    " required by symbol geometry".format(o=offset))
 
         return False
 

--- a/schlib/rules/S3_6.py
+++ b/schlib/rules/S3_6.py
@@ -22,7 +22,7 @@ class Rule(KLCRule):
             self.warningExtra("Pin offset ({o}) should not be below 20mils".format(o=offset))
             return True
         elif offset > 20:
-            self.warning("Pin offset is not preferred value")
+            self.warning("Pin offset not preferred value")
             self.warningExtra("Pin offset ({o}) should be 20mils unless"
                     " required by symbol geometry".format(o=offset))
 


### PR DESCRIPTION
[KLC]: http://kicad-pcb.org/libraries/klc/ "KiCad Library Convention"
[G1.1]: http://kicad-pcb.org/libraries/klc/G1.1/ "Only standard characters are used for naming libraries and components"
[G1.2]: http://kicad-pcb.org/libraries/klc/G1.2/ "Each library is limited to 250 items"
[G1.3]: http://kicad-pcb.org/libraries/klc/G1.3/ "Libraries are organized by functionality"
[G1.4]: http://kicad-pcb.org/libraries/klc/G1.4/ "English language should be used throughout libraries"
[G1.5]: http://kicad-pcb.org/libraries/klc/G1.5/ "Plural naming is to be avoided"
[G1.6]: http://kicad-pcb.org/libraries/klc/G1.6/ "Capitalization conventions"
[G1.7]: http://kicad-pcb.org/libraries/klc/G1.7/ "Library files use Unix style line endings"
[G1.8]: http://kicad-pcb.org/libraries/klc/G1.8/ "Components can only contain features supported in latest stable release"
[G1.9]: http://kicad-pcb.org/libraries/klc/G1.9/ "Dimensional units"
[G2.1]: http://kicad-pcb.org/libraries/klc/G2.1/ "Defining generic and atomic parts"
[S1.1]: http://kicad-pcb.org/libraries/klc/S1.1/ "Symbol libraries should be categorized by function"
[S2.1]: http://kicad-pcb.org/libraries/klc/S2.1/ "General symbol naming guidelines"
[S2.2]: http://kicad-pcb.org/libraries/klc/S2.2/ "Non-functional variations in part number should be replaced with wildcard"
[S2.3]: http://kicad-pcb.org/libraries/klc/S2.3/ "Where atomic parts are available in multiple footprint options, a separate symbol must be drawn for each footprint"
[S3.1]: http://kicad-pcb.org/libraries/klc/S3.1/ "Origin is centered on the middle of the symbol"
[S3.2]: http://kicad-pcb.org/libraries/klc/S3.2/ "Text fields should use a common text size of 50mils"
[S3.3]: http://kicad-pcb.org/libraries/klc/S3.3/ "Symbol outline and fill requirements"
[S3.4]: http://kicad-pcb.org/libraries/klc/S3.4/ "Symbols with complex functionality may incorporate simple functional diagrams"
[S3.5]: http://kicad-pcb.org/libraries/klc/S3.5/ "Pin connection points must be placed outside of the symbol"
[S3.6]: http://kicad-pcb.org/libraries/klc/S3.6/ "Pin name position offset"
[S3.7]: http://kicad-pcb.org/libraries/klc/S3.7/ "Pin numbering for exposed pads"
[S3.8]: http://kicad-pcb.org/libraries/klc/S3.8/ "Multi unit symbols"
[S4.1]: http://kicad-pcb.org/libraries/klc/S4.1/ "General pin requirements"
[S4.2]: http://kicad-pcb.org/libraries/klc/S4.2/ "Pins should be grouped by function"
[S4.3]: http://kicad-pcb.org/libraries/klc/S4.3/ "Rules for pin stacking"
[S4.4]: http://kicad-pcb.org/libraries/klc/S4.4/ "Pin electrical type"
[S4.5]: http://kicad-pcb.org/libraries/klc/S4.5/ "Pins not connected on the footprint may be omitted from the symbol"
[S4.6]: http://kicad-pcb.org/libraries/klc/S4.6/ "Hidden pins"
[S4.7]: http://kicad-pcb.org/libraries/klc/S4.7/ "Active low pins should be designated using a bar above the symbol name"
[S5.1]: http://kicad-pcb.org/libraries/klc/S5.1/ "Symbols with a default footprint link to a valid footprint file"
[S5.2]: http://kicad-pcb.org/libraries/klc/S5.2/ "Footprint filters should match all appropriate footprints"
[S6.1]: http://kicad-pcb.org/libraries/klc/S6.1/ "Component Reference Designator (RefDes)"
[S6.2]: http://kicad-pcb.org/libraries/klc/S6.2/ "Component fields must be filled appropriately"
[S6.3]: http://kicad-pcb.org/libraries/klc/S6.3/ "Component metadata is added to symbol (and all aliases)"
[S7.1]: http://kicad-pcb.org/libraries/klc/S7.1/ "Power flag symbols"
[S7.2]: http://kicad-pcb.org/libraries/klc/S7.2/ "Graphical symbols"
[F1.1]: http://kicad-pcb.org/libraries/klc/F1.1/ "Footprint libraries are categorized by function"
[F1.2]: http://kicad-pcb.org/libraries/klc/F1.2/ "Connector footprint libraries"
[F2.1]: http://kicad-pcb.org/libraries/klc/F2.1/ "General footprint naming conventions"
[F2.2]: http://kicad-pcb.org/libraries/klc/F2.2/ "Footprint naming field prefixes"
[F2.3]: http://kicad-pcb.org/libraries/klc/F2.3/ "Manufacturer specific version of generic footprints"
[F2.4]: http://kicad-pcb.org/libraries/klc/F2.4/ "Footprint naming for non-standard pin numbering"
[F2.5]: http://kicad-pcb.org/libraries/klc/F2.5/ "Footprint naming conventions for specific components"
[F3.1]: http://kicad-pcb.org/libraries/klc/F3.1/ "SMD chip package naming conventions"
[F3.2]: http://kicad-pcb.org/libraries/klc/F3.2/ "Resistor naming conventions"
[F3.3]: http://kicad-pcb.org/libraries/klc/F3.3/ "Capacitor naming conventions"
[F3.4]: http://kicad-pcb.org/libraries/klc/F3.4/ "SMD IC package naming conventions"
[F3.5]: http://kicad-pcb.org/libraries/klc/F3.5/ "THT IC package naming conventions"
[F3.6]: http://kicad-pcb.org/libraries/klc/F3.6/ "Connector naming conventions"
[F3.7]: http://kicad-pcb.org/libraries/klc/F3.7/ "Fuse naming conventions"
[F4.1]: http://kicad-pcb.org/libraries/klc/F4.1/ "Datasheet recommendations take priority"
[F4.2]: http://kicad-pcb.org/libraries/klc/F4.2/ "Pin 1 should be located at the top left"
[F4.3]: http://kicad-pcb.org/libraries/klc/F4.3/ "Connected copper elements have the same pad number"
[F4.4]: http://kicad-pcb.org/libraries/klc/F4.4/ "Thermal pads"
[F4.5]: http://kicad-pcb.org/libraries/klc/F4.5/ "Specifying footprint keepout areas"
[F4.6]: http://kicad-pcb.org/libraries/klc/F4.6/ "Local clearance and settings should be set to zero"
[F5.1]: http://kicad-pcb.org/libraries/klc/F5.1/ "Silkscreen layer requirements"
[F5.2]: http://kicad-pcb.org/libraries/klc/F5.2/ "Fabrication layer requirements"
[F5.3]: http://kicad-pcb.org/libraries/klc/F5.3/ "Courtyard layer requirements"
[F6.1]: http://kicad-pcb.org/libraries/klc/F6.1/ "Footprint placement type must be set to surface mount"
[F6.2]: http://kicad-pcb.org/libraries/klc/F6.2/ "Footprint anchor should be placed in the middle of the component body"
[F6.3]: http://kicad-pcb.org/libraries/klc/F6.3/ "Pad requirements for SMD footprints"
[F7.1]: http://kicad-pcb.org/libraries/klc/F7.1/ "Footprint placement type must be set to Through Hole"
[F7.2]: http://kicad-pcb.org/libraries/klc/F7.2/ "Footprint anchor should placed at the location of Pin-1"
[F7.3]: http://kicad-pcb.org/libraries/klc/F7.3/ "Pin 1 should be rectangular, and other pads circular or oval"
[F7.4]: http://kicad-pcb.org/libraries/klc/F7.4/ "Pad requirements for THT footprints"
[F7.5]: http://kicad-pcb.org/libraries/klc/F7.5/ "Minimum annular ring width"
[F7.6]: http://kicad-pcb.org/libraries/klc/F7.6/ "Minimum hole diameter"
[F8.1]: http://kicad-pcb.org/libraries/klc/F8.1/ "Virtual components"
[F9.1]: http://kicad-pcb.org/libraries/klc/F9.1/ "Footprint meta-data is filled in as appropriate"
[F9.2]: http://kicad-pcb.org/libraries/klc/F9.2/ "Footprint properties are as default values unless otherwise required in datasheet"
[F9.3]: http://kicad-pcb.org/libraries/klc/F9.3/ "Footprint 3D model requirements"
[M1.1]: http://kicad-pcb.org/libraries/klc/M1.1/ "Models should be created by contributor"
[M1.2]: http://kicad-pcb.org/libraries/klc/M1.2/ "Manufacturer models should not be duplicated"
[M1.3]: http://kicad-pcb.org/libraries/klc/M1.3/ "Source files for 3D models should be supplied"
[M2.1]: http://kicad-pcb.org/libraries/klc/M2.1/ "Permitted 3D model file types"
[M2.2]: http://kicad-pcb.org/libraries/klc/M2.2/ "Model alignment and scaling"

KLC says that the preferred pin name position offset is 20 mil, and that larger values up to 50 mil are allowed for unusual symbol geometry ([S3.6]).

This commit causes ~an info message~ a warning to be printed if the offset is > 20 mil, because I keep failing to catch that for rectangular symbols where it should be 20 mil.