### PR TITLE
S3.6: Allow offset to be 0

### DIFF
--- a/schlib/rules/S3_6.py
+++ b/schlib/rules/S3_6.py
@@ -13,7 +13,12 @@ class Rule(KLCRule):
 
         offset = int(self.component.definition['text_offset'])
 
-        if offset > 50:
+        if offset == 0:
+            # An offset of 0 means the text is placed next to the pin, not
+            # inside the symbol.  As the offset only applies when the text is
+            # inside the symbol, this case is perfectly OK.
+            return False
+        elif offset > 50:
             self.error("Pin offset outside allowed range")
             self.errorExtra("Pin offset ({o}) must not be above 50mils".format(o=offset))
             return True


### PR DESCRIPTION
An offset of 0 in the library file is special: it means the pin name is next to the pin rather than inside the symbol.  In some cases, that's the only way to draw the pin name, so there's nothing wrong if we're in that case.  This PR makes the script silent when the offset is set to 0.