### PR TITLE
Issue a warning for missing footprint field

### DIFF
--- a/schlib/rules/S5_1.py
+++ b/schlib/rules/S5_1.py
@@ -88,10 +88,13 @@ class Rule(KLCRule):
                 if len(filters)>1:
                     self.error("Symbol has a footprint defined in the footprint field, but several ({fpcnt}) footprint filters set. If the symbol is for a single default footprint, remove the surplus filters. If the symbol is meant for multiple different footprints, empty the footprint field.".format(fpcnt=len(filters)))
                     fails=True
-            else:
-                if len(filters)==1:
-                    self.error("Symbol has a single fooprint filter string '"+filters[0]+"' (i.e. it seems to be intended for a single default footprint only), but the footprint field is empty. Fill footprint field with the correct footprint in the form LIBRARY:FOOTPRINT.")
-                    fails=True
+            elif len(filters)==1:
+                self.warning("Symbol possibly missing default footprint")
+                self.warningExtra("Symbol has a single footprint filter "
+                        "string '{fil}' (i.e. it may be intended for a single "
+                        "default footprint only), but the footprint field is "
+                        "empty.".format(fil=filters[0]))
+                fails=True
 
 
         return fail


### PR DESCRIPTION
As pointed out in #234, there are plenty of cases where a symbol having one footprint filter and no default footprint is valid, and therefore this shouldn't be treated as an error by the script.

This commit changes that case to a warning, splits up the message into a warning and a warningExtra, and shortens the message overall by not explicitly saying how to fix the problem if it in fact is a problem.

Fixes #234.