### PR TITLE
Move rule descriptions to rule class docstrings

### DIFF
--- a/common/rulebase.py
+++ b/common/rulebase.py
@@ -91,8 +91,8 @@ class KLCRuleBase(object):
         path = "".join(path.split(".")[:-1])
         return path.replace('_', '.')
 
-    def __init__(self, description):
-        self.description = description
+    def __init__(self):
+        self.description = self.__doc__.strip().splitlines()[0].strip()
         self.messageBuffer=[]
         self.resetErrorCount()
         self.resetWarningCount()

--- a/pcb/rules/F5_1.py
+++ b/pcb/rules/F5_1.py
@@ -7,11 +7,7 @@ from rules.klc_constants import *
 import cmath
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
-    def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, "Silkscreen layer requirements")
+    """Silkscreen layer requirements"""
 
     def checkReference(self):
         """

--- a/pcb/rules/F5_2.py
+++ b/pcb/rules/F5_2.py
@@ -10,11 +10,7 @@ from rules.klc_constants import *
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
-    def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, "Fabrication layer requirements")
+    """Fabrication layer requirements"""
 
     # Check for presence of component value
     def checkMissingValue(self):

--- a/pcb/rules/F5_3.py
+++ b/pcb/rules/F5_3.py
@@ -16,11 +16,7 @@ sys.path.append(os.path.join('..','..','common'))
 from boundingbox import BoundingBox
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
-    def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, "Courtyard layer requirements")
+    """Courtyard layer requirements"""
 
     # Get the superposed boundary of pads and fab layer
     def getFootprintBounds(self):

--- a/pcb/rules/F6_1.py
+++ b/pcb/rules/F6_1.py
@@ -5,11 +5,7 @@ from __future__ import division
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
-    def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, 'For surface-mount devices, placement type must be set to "Surface Mount"')
+    """Footprint placement type must be set to surface mount"""
 
     def check(self):
         """

--- a/pcb/rules/F6_2.py
+++ b/pcb/rules/F6_2.py
@@ -5,11 +5,7 @@ from __future__ import division
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
-    def __init__(self, module, args):
-        super(Rule, self).__init__(module, args,'For surface-mount devices, footprint anchor is placed in the middle of the footprint (IPC-7351).')
+    """Footprint anchor should be placed in the middle of the component body"""
 
     def check(self):
         """

--- a/pcb/rules/F6_3.py
+++ b/pcb/rules/F6_3.py
@@ -3,11 +3,10 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
+    """Pad requirements for SMD footprints"""
+
     def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, 'Pad requirements for SMD footprints')
+        super(Rule, self).__init__(module, args)
 
         self.required_layers = ["Cu", "Paste", "Mask"]
         self.sides = ["F.", "B."]

--- a/pcb/rules/F7_1.py
+++ b/pcb/rules/F7_1.py
@@ -5,11 +5,7 @@ from __future__ import division
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
-    def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, 'For through-hole devices, placement type must be set to "Through Hole"')
+    """Footprint placement type must be set to Through Hole"""
 
     def check(self):
         """

--- a/pcb/rules/F7_2.py
+++ b/pcb/rules/F7_2.py
@@ -3,11 +3,10 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
+    """Footprint anchor should placed at the location of Pin-1"""
+
     def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, 'For through-hole components, footprint anchor is set on pad 1')
+        super(Rule, self).__init__(module, args)
 
         self.pin1_position = []
         self.pin1_count = 0

--- a/pcb/rules/F7_3.py
+++ b/pcb/rules/F7_3.py
@@ -3,11 +3,10 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
+    """Pin 1 should be rectangular, and other pads circular or oval"""
+
     def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, 'Pad 1 should be denoted by rectangular pad')
+        super(Rule, self).__init__(module, args)
 
         self.names = ['1', 'A', 'A1', 'P1', 'PAD1']
 

--- a/pcb/rules/F7_4.py
+++ b/pcb/rules/F7_4.py
@@ -3,11 +3,10 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
+    """Pad requirements for THT footprints"""
+
     def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, 'Pad requirements for THT footprints')
+        super(Rule, self).__init__(module, args)
 
         self.required_layers = ["*.Cu","*.Mask"]
 

--- a/pcb/rules/F7_5.py
+++ b/pcb/rules/F7_5.py
@@ -5,11 +5,7 @@ from __future__ import division
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
-    def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, 'Annular ring must be at least 0.15mm')
+    """Minimum annular ring width"""
 
     def checkPad(self, pad):
         if not 'size' in pad['drill']:

--- a/pcb/rules/F7_6.py
+++ b/pcb/rules/F7_6.py
@@ -3,11 +3,7 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
-    def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, 'Minimum hole drill size')
+    """Minimum hole diameter"""
 
     def checkPad(self, pad):
 

--- a/pcb/rules/F9_1.py
+++ b/pcb/rules/F9_1.py
@@ -4,11 +4,7 @@ from rules.rule import *
 import os
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
-    def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, 'Footprint metadata must be filled as appropriate')
+    """Footprint meta-data is filled in as appropriate"""
 
     def checkDocs(self):
         mod = self.module

--- a/pcb/rules/F9_2.py
+++ b/pcb/rules/F9_2.py
@@ -3,11 +3,7 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
-    def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, 'Footprint properties should be left to default values.')
+    """Footprint properties are as default values unless otherwise required in datasheet"""
 
     def check(self):
         """

--- a/pcb/rules/F9_3.py
+++ b/pcb/rules/F9_3.py
@@ -6,11 +6,7 @@ import os
 SYSMOD_PREFIX = "${KISYS3DMOD}/"
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad_mod files.
-    """
-    def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, '3D model settings')
+    """Footprint 3D model requirements"""
 
     def checkModel(self, model):
 

--- a/pcb/rules/G1_1.py
+++ b/pcb/rules/G1_1.py
@@ -4,11 +4,10 @@ from rules.rule import *
 import re
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
+    """Only standard characters are used for naming libraries and components"""
+
     def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, 'Illegal characters in footprint name')
+        super(Rule, self).__init__(module, args)
         # Set of allowed chars. Some characters need to be escaped.
         allowed_chars = "a-zA-Z0-9_\-\.,\+"
         self.pattern = re.compile('^['+allowed_chars+']+$')

--- a/pcb/rules/G1_7.py
+++ b/pcb/rules/G1_7.py
@@ -4,11 +4,7 @@ from rules.rule import *
 import platform
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, module, args):
-        super(Rule, self).__init__(module, args, 'Library files must use Unix-style line endings (LF)')
+    """Library files use Unix style line endings"""
 
     def check(self):
 

--- a/pcb/rules/rule.py
+++ b/pcb/rules/rule.py
@@ -78,12 +78,13 @@ def graphItemString(graph, layer=False, width=False):
     return shapeText + layerText + widthText
 
 class KLCRule(KLCRuleBase):
-    """
-    A base class to represent a KLC rule
-    """
-    def __init__(self, module, args, description):
+    """A base class to represent a KLC rule
 
-        KLCRuleBase.__init__(self, description)
+    Create the methods check and fix to use with the kicad_mod files.
+    """
+    def __init__(self, module, args):
+
+        KLCRuleBase.__init__(self)
     
         self.module = module
         self.args = args

--- a/schlib/rules/EC01.py
+++ b/schlib/rules/EC01.py
@@ -4,11 +4,7 @@ from rules.rule import *
 import re
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'General pin number checking')
+    """General pin number checking"""
 
     def checkPinNames(self):
         self.wrong_pin_numbers = []

--- a/schlib/rules/EC02.py
+++ b/schlib/rules/EC02.py
@@ -3,11 +3,7 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'Check part reference, name and footprint position and alignment')
+    """Check part reference, name and footprint position and alignment"""
 
     def check(self):
         """

--- a/schlib/rules/G1_1.py
+++ b/schlib/rules/G1_1.py
@@ -4,11 +4,7 @@ from rules.rule import *
 import string
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'Illegal characters in symbol name')
+    """Only standard characters are used for naming libraries and components"""
 
     def check(self):
 

--- a/schlib/rules/S3_1.py
+++ b/schlib/rules/S3_1.py
@@ -4,11 +4,7 @@ from rules.rule import *
 import math
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'Origin is centered on the middle of the symbol')
+    """Origin is centered on the middle of the symbol"""
 
     def check(self):
         """

--- a/schlib/rules/S3_2.py
+++ b/schlib/rules/S3_2.py
@@ -3,11 +3,7 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'Text fields should use common size of 50mils, but labels and numbers may use text size as low as 20mil if required')
+    """Text fields should use a common text size of 50mils"""
 
     def check(self):
         """

--- a/schlib/rules/S3_3.py
+++ b/schlib/rules/S3_3.py
@@ -3,11 +3,7 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'Symbol outline and fill requirements')
+    """Symbol outline and fill requirements"""
 
     def check(self):
         """

--- a/schlib/rules/S3_6.py
+++ b/schlib/rules/S3_6.py
@@ -3,11 +3,7 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'Pin name position offset')
+    """Pin name position offset"""
 
     def check(self):
 

--- a/schlib/rules/S4_1.py
+++ b/schlib/rules/S4_1.py
@@ -3,11 +3,7 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'Pin requirements')
+    """General pin requirements"""
 
     def checkPinOrigin(self, gridspacing=100):
         self.violating_pins = []

--- a/schlib/rules/S4_2.py
+++ b/schlib/rules/S4_2.py
@@ -4,11 +4,7 @@ from rules.rule import *
 import re
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'Pins should be arranged by function')
+    """Pins should be grouped by function"""
 
     def checkGroundPins(self):
 

--- a/schlib/rules/S4_3.py
+++ b/schlib/rules/S4_3.py
@@ -3,11 +3,10 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
+    """Rules for pin stacking"""
+
     def __init__(self, component):
-        super(Rule, self).__init__(component, 'Rules for pin stacking')
+        super(Rule, self).__init__(component)
         self.different_names=False
         self.NC_stacked=False
         self.different_types=False

--- a/schlib/rules/S4_4.py
+++ b/schlib/rules/S4_4.py
@@ -4,6 +4,7 @@ from rules.rule import *
 import re
 
 class Rule(KLCRule):
+    """Pin electrical type"""
 
     #Power Input Pins should be 'W'
     POWER_INPUTS = ['^[ad]*g(rou)*nd$', '^[ad]*v(aa|cc|dd|ss|bat|in)$']
@@ -38,12 +39,6 @@ class Rule(KLCRule):
                 return True
 
         return False
-
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'Pin electrical type should match pin function')
 
     # These pin types must be satisfied
     def checkPowerPins(self, pins):

--- a/schlib/rules/S4_6.py
+++ b/schlib/rules/S4_6.py
@@ -4,6 +4,7 @@ from rules.rule import *
 import re
 
 class Rule(KLCRule):
+    """Hidden pins"""
 
     #No-connect pins should be "N"
     NC_PINS = ['^nc$', '^dnc$', '^n\.c\.$']
@@ -16,12 +17,6 @@ class Rule(KLCRule):
                 return True
 
         return False
-
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'Unused pins should be set as NOT CONNECTED and should be INVISIBLE')
 
     def checkNCPins(self, pins):
 

--- a/schlib/rules/S5_1.py
+++ b/schlib/rules/S5_1.py
@@ -4,11 +4,7 @@ from rules.rule import *
 import fnmatch
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'For components with a single default footprint, footprint field is filled with valid footprint filename')
+    """Symbols with a default footprint link to a valid footprint file"""
 
     def check(self):
         """

--- a/schlib/rules/S5_2.py
+++ b/schlib/rules/S5_2.py
@@ -4,11 +4,7 @@ from rules.rule import *
 import re
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'Footprint filters should match all appropriate footprints')
+    """Footprint filters should match all appropriate footprints"""
 
     def checkFilters(self, filters):
 

--- a/schlib/rules/S6_2.py
+++ b/schlib/rules/S6_2.py
@@ -3,11 +3,7 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'Component fields contain the correct information')
+    """Component fields must be filled appropriately"""
 
     def checkVisibility(self, field):
         return field['visibility'] == 'V'

--- a/schlib/rules/S6_3.py
+++ b/schlib/rules/S6_3.py
@@ -3,11 +3,7 @@
 from rules.rule import *
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
-    def __init__(self, component):
-        super(Rule, self).__init__(component, 'Part meta-data is filled in as appropriate')
+    """Component metadata is added to symbol (and all aliases)"""
 
     def check(self):
         """

--- a/schlib/rules/S7_1.py
+++ b/schlib/rules/S7_1.py
@@ -4,11 +4,10 @@ from rules.rule import *
 import re
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
+    """Power flag symbols"""
+
     def __init__(self, component):
-        super(Rule, self).__init__(component, 'Power-flag symbols follow some special rules/KLC-exceptions')
+        super(Rule, self).__init__(component)
         self.makePinINVISIBLE=False
         self.makePinPowerInput=False
         self.fixTooManyPins=False

--- a/schlib/rules/S7_2.py
+++ b/schlib/rules/S7_2.py
@@ -4,11 +4,10 @@ from rules.rule import *
 import re
 
 class Rule(KLCRule):
-    """
-    Create the methods check and fix to use with the kicad lib files.
-    """
+    """Graphical symbols"""
+
     def __init__(self, component):
-        super(Rule, self).__init__(component, 'Graphical symbols follow some special rules/KLC-exceptions')
+        super(Rule, self).__init__(component)
         self.fixTooManyPins=False
         self.fixNoFootprint=False
 

--- a/schlib/rules/rule.py
+++ b/schlib/rules/rule.py
@@ -67,14 +67,15 @@ def positionFormater(element):
     # return "pos [{0},{1}]".format(element['posx'],element['posy'])
 
 class KLCRule(KLCRuleBase):
-    """
-    A base class to represent a KLC rule
+    """A base class to represent a KLC rule
+
+    Create the methods check and fix to use with the kicad lib files.
     """
 
     verbosity = 0
 
-    def __init__(self, component, description):
+    def __init__(self, component):
 
-        KLCRuleBase.__init__(self, description)
+        KLCRuleBase.__init__(self)
 
         self.component = component


### PR DESCRIPTION
As I wrote in #220, the rule class docstrings seem like a more sensible place for rule descriptions than burying them in the `__init__` method.  I offered to make this change a couple of months ago, and have seen no objections, so here it is.

While moving the descriptions, I changed them all to match the one-line rule names in KLC 3.0.11, the current revision.  All the docstrings I touched now come at least reasonably close to following [PEP 257](https://www.python.org/dev/peps/pep-0257/).  Hooray for good code style!

In moving the descriptions out of the constructor, many rule classes no longer need to define their own constructors at all, so overall this reduces how much code we have to maintain.

Fixes #220.