### PR TITLE
Warn about non-nominal silk and fab line widths

### DIFF
--- a/pcb/rules/F5_1.py
+++ b/pcb/rules/F5_1.py
@@ -63,10 +63,13 @@ class Rule(KLCRule):
     def checkSilkscreenWidth(self):
         # check the width
         self.bad_width = []
+        self.non_nominal_width = []
 
         for graph in (self.f_silk + self.b_silk):
             if graph['width'] not in KLC_SILK_WIDTH_ALLOWED:
                 self.bad_width.append(graph)
+            elif graph['width'] != KLC_SILK_WIDTH:
+                self.non_nominal_width.append(graph)
 
     """
     Check if any of the silkscreen intersects
@@ -204,6 +207,7 @@ class Rule(KLCRule):
             * f_silk
             * b_silk
             * bad_width
+            * non_nominal_width
         """
         module = self.module
         self.f_silk = module.filterGraphs('F.SilkS')
@@ -220,9 +224,16 @@ class Rule(KLCRule):
 
         # Display message if bad silkscreen width was found
         if self.bad_width:
-            self.error("Some silkscreen lines have incorrect width: Allowed = {allowed}(mm))".format(allowed=KLC_SILK_WIDTH_ALLOWED))
+            self.error("Some silkscreen lines have incorrect width: Allowed "
+                       "= {allowed} mm".format(allowed=KLC_SILK_WIDTH_ALLOWED))
             for g in self.bad_width:
                 self.errorExtra(graphItemString(g, layer=True, width=True))
+
+        if self.non_nominal_width:
+            self.warning("Some silkscreen lines are not using the nominal "
+                         "width of {width} mm".format(width=KLC_SILK_WIDTH))
+            for g in self.non_nominal_width:
+                self.warningExtra(graphItemString(g, layer=True, width=True))
 
         # Display message if silkscreen was found intersecting with pad
         if self.intersections:

--- a/pcb/rules/F5_2.py
+++ b/pcb/rules/F5_2.py
@@ -149,19 +149,32 @@ class Rule(KLCRule):
     # Check fab line widths
     def checkIncorrectWidth(self):
         self.bad_fabrication_width = []
+        self.non_nominal_width = []
         for graph in (self.f_fabrication_all + self.b_fabrication_all):
-            if graph['width'] < KLC_FAB_WIDTH_MIN or graph['width'] > KLC_FAB_WIDTH_MAX:
+            if (graph['width'] < KLC_FAB_WIDTH_MIN
+                    or graph['width'] > KLC_FAB_WIDTH_MAX):
                 self.bad_fabrication_width.append(graph)
+            elif graph['width'] != KLC_FAB_WIDTH:
+                self.non_nominal_width.append(graph)
 
         msg = False
 
-        if len(self.bad_fabrication_width) > 0:
-            self.error("Some fabrication layer lines have a width outside allowed range of [{x}mm - {y}mm]".format(
-                x = KLC_FAB_WIDTH_MIN,
-                y = KLC_FAB_WIDTH_MAX))
+        if self.bad_fabrication_width:
+            self.error("Some fabrication layer lines have a width outside "
+                       "allowed range of [{min}mm - {max}mm]".format(
+                       min = KLC_FAB_WIDTH_MIN,
+                       max = KLC_FAB_WIDTH_MAX))
 
             for g in self.bad_fabrication_width:
                 self.errorExtra(graphItemString(g, layer=True, width=True))
+
+        if self.non_nominal_width:
+            self.warning("Some fabrication layer lines are not using the "
+                       "nominal width of {width} mm".format(
+                       width = KLC_FAB_WIDTH))
+
+            for g in self.non_nominal_width:
+                self.warningExtra(graphItemString(g, layer=True, width=True))
 
         return len(self.bad_fabrication_width) > 0
 
@@ -174,6 +187,7 @@ class Rule(KLCRule):
             * f_fabrication_lines
             * b_fabrication_lines
             * bad_fabrication_width
+            * non_nominal_width
         """
 
         self.missing_value = False


### PR DESCRIPTION
As pointed out in #217, it's appropriate to give warnings for non-nominal line widths on the silkscreen and fabrication layers.  This PR changes the checking scripts for rules F5.1 and F5.2 to give these warnings.

For an example of the new output, try running this PR's branch on RF_Module.pretty, as some components in that library have quite a few of both new warnings.

Fixes #217.