### PR TITLE
Extract footprint-center from F.Fab outline

### DIFF
--- a/pcb/rules/F6_2.py
+++ b/pcb/rules/F6_2.py
@@ -46,10 +46,10 @@ class Rule(KLCRule):
         THRESHOLD = 0.001
         if abs(x) > THRESHOLD or abs(y) > THRESHOLD:
             self.error("Footprint anchor does not match calculated center of Pads or F.Fab")
-            self.errorExtra("calculated centers for Pads [{xp},{yp}mm]".format(
+            self.errorExtra("calculated center for Pads [{xp},{yp}mm]".format(
                 xp = round(center_pads['x'], 5),
                 yp = round(center_pads['y'], 5)))
-            self.errorExtra("calculated centers for F.Fab [{xf},{yf}mm]".format(
+            self.errorExtra("calculated center for F.Fab [{xf},{yf}mm]".format(
                 xf = round(center_fab['x'], 5),
                 yf = round(center_fab['y'], 5)))
 

--- a/pcb/rules/F6_2.py
+++ b/pcb/rules/F6_2.py
@@ -3,6 +3,7 @@
 from __future__ import division
 
 from rules.rule import *
+from math import sqrt
 
 class Rule(KLCRule):
     """
@@ -24,19 +25,31 @@ class Rule(KLCRule):
             # Ignore non-smd parts
             return False
 
-        center = module.padMiddlePosition()
+        center_pads = module.padMiddlePosition()
+        center_fab  = module.geometricBoundingBox("F.Fab").center
+
+        if center_pads['x'] != center_fab['x'] or center_pads['y'] != center_fab['y']:
+            self.warning("Footprint centers of pads and F.Fab do not match")
+            self.warningExtra("Footprint center calculated as Pad: ({xp},{yp})mm F.Fab: ({xf}, {yf})mm".format(
+                xp = round(center_pads['x'], 5),
+                yp = round(center_pads['y'], 5),
+                xf = round(center_fab['x'], 5),
+                yf = round(center_fab['y'], 5)))
 
         err = False
 
         THRESHOLD = 0.001
-        x = center['x']
-        y = center['y']
+        # select the xy coordinates that are closest to the center
+        diff_pads = sqrt(center_pads['x']**2 + center_pads['y']**2)
+        diff_fab  = sqrt(center_fab['x']**2 +  center_fab['y']**2)
+        x = (center_pads['x'], center_fab['x'])[diff_pads > diff_fab]
+        y = (center_pads['y'], center_fab['y'])[diff_pads > diff_fab]
 
         if abs(x) > THRESHOLD or abs(y) > THRESHOLD:
             self.error("Footprint anchor is not located at center of footprint")
             self.errorExtra("Footprint center calculated as ({x},{y})mm".format(
-                x = round(center['x'], 5),
-                y = round(center['y'], 5)))
+                x = round(x, 5),
+                y = round(y, 5)))
 
             err = True
 

--- a/pcb/rules/F6_2.py
+++ b/pcb/rules/F6_2.py
@@ -18,6 +18,11 @@ class Rule(KLCRule):
         The following variables will be accessible after checking:
             * center_pads
             * center_fab
+
+        This test will generate false positives for parts that have a weird outline, are not symmetrical or do not have 
+        the pick'n'place location in the geometrical center.
+        Most connectors will have at least one of those issues (e.g. a FPC-Connector) and fail this test.
+        For most other components (LEDs, molded packages, ...) this test will yield usable results.
         """
         module = self.module
         if module.attribute != 'smd':
@@ -40,14 +45,13 @@ class Rule(KLCRule):
 
         THRESHOLD = 0.001
         if abs(x) > THRESHOLD or abs(y) > THRESHOLD:
-            self.error("Footprint anchor is not located at center of footprint")
-            self.errorExtra("Footprint center calculated as Pad: ({xp},{yp})mm F.Fab: ({xf}, {yf})mm".format(
+            self.error("Footprint anchor does not match calculated center of Pads or F.Fab")
+            self.errorExtra("calculated centers for Pads [{xp},{yp}mm]".format(
                 xp = round(center_pads['x'], 5),
-                yp = round(center_pads['y'], 5),
+                yp = round(center_pads['y'], 5)))
+            self.errorExtra("calculated centers for F.Fab [{xf},{yf}mm]".format(
                 xf = round(center_fab['x'], 5),
                 yf = round(center_fab['y'], 5)))
-            if center_pads['x'] != center_fab['x'] or center_pads['y'] != center_fab['y']:
-                self.errorExtra("Footprint centers of pads and F.Fab do not match")
 
             err = True
 
@@ -56,7 +60,7 @@ class Rule(KLCRule):
     def fix(self):
         """
         Proceeds the fixing of the rule, if possible.
-	This fix will always use the pads center position.
+        This fix will always use the pads center position.
         """
         module = self.module
         if self.check():

--- a/pcb/rules/F6_2.py
+++ b/pcb/rules/F6_2.py
@@ -16,9 +16,8 @@ class Rule(KLCRule):
         """
         Proceeds the checking of the rule.
         The following variables will be accessible after checking:
-            * pads_bounds
-            * pads_distance
-            * right_anchor
+            * center_pads
+            * center_fab
         """
         module = self.module
         if module.attribute != 'smd':
@@ -38,13 +37,16 @@ class Rule(KLCRule):
 
         err = False
 
-        THRESHOLD = 0.001
-        # select the xy coordinates that are closest to the center
+        # calculate the distance from origin for the pads and fab
         diff_pads = sqrt(center_pads['x']**2 + center_pads['y']**2)
         diff_fab  = sqrt(center_fab['x']**2 +  center_fab['y']**2)
-        x = (center_pads['x'], center_fab['x'])[diff_pads > diff_fab]
-        y = (center_pads['y'], center_fab['y'])[diff_pads > diff_fab]
+        # select the xy coordinates that are closest to the center
+        if diff_pads > diff_fab:
+            (x, y) = (center_fab['x'], center_fab['y'])
+        else:
+            (x, y) = (center_pads['x'], center_pads['y'])
 
+        THRESHOLD = 0.001
         if abs(x) > THRESHOLD or abs(y) > THRESHOLD:
             self.error("Footprint anchor is not located at center of footprint")
             self.errorExtra("Footprint center calculated as ({x},{y})mm".format(
@@ -58,6 +60,7 @@ class Rule(KLCRule):
     def fix(self):
         """
         Proceeds the fixing of the rule, if possible.
+	This fix will always use the pads center position.
         """
         module = self.module
         if self.check():

--- a/pcb/rules/F6_2.py
+++ b/pcb/rules/F6_2.py
@@ -27,14 +27,6 @@ class Rule(KLCRule):
         center_pads = module.padMiddlePosition()
         center_fab  = module.geometricBoundingBox("F.Fab").center
 
-        if center_pads['x'] != center_fab['x'] or center_pads['y'] != center_fab['y']:
-            self.warning("Footprint centers of pads and F.Fab do not match")
-            self.warningExtra("Footprint center calculated as Pad: ({xp},{yp})mm F.Fab: ({xf}, {yf})mm".format(
-                xp = round(center_pads['x'], 5),
-                yp = round(center_pads['y'], 5),
-                xf = round(center_fab['x'], 5),
-                yf = round(center_fab['y'], 5)))
-
         err = False
 
         # calculate the distance from origin for the pads and fab
@@ -49,9 +41,13 @@ class Rule(KLCRule):
         THRESHOLD = 0.001
         if abs(x) > THRESHOLD or abs(y) > THRESHOLD:
             self.error("Footprint anchor is not located at center of footprint")
-            self.errorExtra("Footprint center calculated as ({x},{y})mm".format(
-                x = round(x, 5),
-                y = round(y, 5)))
+            self.errorExtra("Footprint center calculated as Pad: ({xp},{yp})mm F.Fab: ({xf}, {yf})mm".format(
+                xp = round(center_pads['x'], 5),
+                yp = round(center_pads['y'], 5),
+                xf = round(center_fab['x'], 5),
+                yf = round(center_fab['y'], 5)))
+            if center_pads['x'] != center_fab['x'] or center_pads['y'] != center_fab['y']:
+                self.errorExtra("Footprint centers of pads and F.Fab do not match")
 
             err = True
 


### PR DESCRIPTION
Some footprints have weird pad shapes, making the F6.2 test fail.
To fix this, we can also calculate the center of the F.Fab layer. Of those
two possible center-locations, the one closer to (0,0) is
selected.
If Pads-center and F.Fab-center differ a warning is displayed.

--------------------

This fixes the travis error for this PR https://github.com/KiCad/kicad-footprints/pull/951