### PR TITLE
extends the range of Conn_2Rows to 75 pins 

### DIFF
--- a/schlib/autogen/connector/Connector_generator.py
+++ b/schlib/autogen/connector/Connector_generator.py
@@ -15,7 +15,7 @@ import argparse
 pin_per_row_range = range(1,41)
 pin_per_row_range_dual = range(2,41) #for some dual row connectors all numbering schemes generate the same symbol for the 1 pin per row variant.
 pin_per_row_range_screw = range(1,21)
-pin_range_dual_row_odd_count = range(2,35)
+pin_range_dual_row_odd_count = range(2,38)
 
 reference_designator = 'J'
 


### PR DESCRIPTION
Reason is preparation of https://github.com/KiCad/kicad-footprints/pull/879

It adds 3 new connectors.
The previous limit was afaik arbitrary.