### PR TITLE
G1.7 should produce an error, not a warning

### DIFF
--- a/pcb/rules/G1_7.py
+++ b/pcb/rules/G1_7.py
@@ -15,8 +15,8 @@ class Rule(KLCRule):
         # Only perform this check on linux systems (i.e. Travis)
         # Windows automatically checks out with CR+LF line endings
         if 'linux' in platform.platform().lower() and not self.module.unix_line_endings:
-            self.warning("Incorrect line ending")
-            self.warningExtra("Library files must use Unix-style line endings (LF)")
+            self.error("Incorrect line endings")
+            self.errorExtra("Library files must use Unix-style line endings (LF)")
             return True
 
         return False


### PR DESCRIPTION
The [wording of this rule](http://kicad-pcb.org/libraries/klc/G1.7/) "must always" suggests that this check should error out if it encounters a file with CRLF line endings. The .gitattributes file should catch most of these by automatically converting to LF during the commit, but apparently it does not apply when committing through the browser.

The unfortunate part is that when working on Windows, running the check before committing will show this error, but provided there are no other issues flagged you can just commit anyway and reset your working tree.