### PR TITLE
Use option flag to decide if symbol is a power symbol

### DIFF
--- a/schlib/schlib.py
+++ b/schlib/schlib.py
@@ -293,7 +293,7 @@ class Component(object):
         return self.reference.startswith('#')
 
     def isPowerSymbol(self):
-        return (self.reference=='#PWR') and (len(self.pins)==1) and (self.pins[0]['electrical_type'].lower()=='w')
+        return self.definition['option_flag'] == 'P'
 
     def isPossiblyPowerSymbol(self):
         return (self.reference=='#PWR')


### PR DESCRIPTION
This fixes the PWR_FLAG violating KLC rule S6.2 "Ref(erence) field must be VISIBLE" because it does not use the #PWR reference.