### PR TITLE
Add exclude option to checklib to exclude particular rules

### DIFF
--- a/schlib/checklib.py
+++ b/schlib/checklib.py
@@ -26,6 +26,7 @@ parser.add_argument('libfiles', nargs='+')
 parser.add_argument('-c', '--component', help='check only a specific component (implicitly verbose)', action='store')
 parser.add_argument('-p', '--pattern', help='Check multiple components by matching a regular expression', action='store')
 parser.add_argument('-r','--rule',help='Select a particular rule (or rules) to check against (default = all rules). Use comma separated values to select multiple rules. e.g. "-r 3.1,EC02"')
+parser.add_argument('-e','--exclude',help='Exclude a particular rule (or rules) to check against. Use comma separated values to select multiple rules. e.g. "-e 3.1,EC02"')
 parser.add_argument('--fix', help='fix the violations if possible', action='store_true')
 parser.add_argument('--nocolor', help='does not use colors to show the output', action='store_true')
 parser.add_argument('-v', '--verbose', help='Enable verbose output. -v shows brief information, -vv shows complete information', action='count')
@@ -51,12 +52,18 @@ else:
     #ALL rules are used
     selected_rules = None
 
+if args.exclude:
+    excluded_rules = args.exclude.split(',')
+else:
+    excluded_rules = None
+
 rules = []
 
 for r in all_rules:
     r_name = r.replace('_', '.')
     if selected_rules == None or r_name in selected_rules:
-        rules.append(globals()[r].Rule)
+        if excluded_rules == None or r_name not in excluded_rules:
+            rules.append(globals()[r].Rule)
 
 #grab list of libfiles (even on windows!)
 libfiles = []


### PR DESCRIPTION
This allows to exclude rules checklib.py should not check against. In a lot of cases this makes more sense than just enabling a subset of rules, since some rules might not fit certain libraries.

E.g a lot of symbols in the mainline MCU_Microchip_ATmega.lib library violate S4.4 and almost all symbols in MCU_ST_STM32F4.lib violate S3.1.

This could be easily ignored by running

```
checklib.py MCU_Microchip_ATmega.lib -e S4.4 -vv
checklib.py MCU_ST_STM32F4.lib -e S3.1 -vv
```

Allowing to ignore the "noise", making it easier to spot new mistakes that might actually matter.