### PR TITLE
Seperate LibTable class from check_lib_table functionality

### DIFF
--- a/check_lib_table.py
+++ b/check_lib_table.py
@@ -14,100 +14,62 @@ It is important that the official libraries match the entries in these tables.
 from __future__ import print_function
 
 import argparse
-import re
 import os
 import sys
 
-parser = argparse.ArgumentParser(description='Compare a sym_lib_table file against a list of .lib library files')
+from lib_table import LibTable
+
+parser = argparse.ArgumentParser(description='Compare a sym-lib-table file against a list of .lib library files')
 parser.add_argument('libs', nargs='+', help='.lib files')
-parser.add_argument('-t', '--table', help='sym_lib_table file', action='store')
+parser.add_argument('-t', '--table', help='sym-lib-table file', action='store')
 
 args = parser.parse_args()
 
-class LibTable:
 
-    def __init__(self, filename):
+def check_entries(lib_table, lib_names):
 
-        RE_NAME = r'\(name "?([^\)"]*)"?\)'
-        RE_TYPE = r'\(type "?([^\)"]*)"?\)'
-        RE_URI  = r'\(uri "?([^\)"]*)"?\)'
-        RE_OPT  = r'\(options "?([^\)"]*)"?\)'
-        RE_DESC = r'\(descr "?([^\)"]*)"?'
+    errors = 0
 
-        self.entries = []
-        self.errors = []
+    # Check for entries that are incorrectly formatted
+    for entry in lib_table.entries:
+        nickname = entry['name']
+        uri = entry['uri']
 
-        with open(filename, 'r') as lib_table_file:
-
-            for line in lib_table_file:
-
-                # Skip lines that do not define a library
-                if not '(lib ' in line:
-                    continue
-
-                re_name = re.search(RE_NAME, line)
-                re_type = re.search(RE_TYPE, line)
-                re_uri  = re.search(RE_URI,  line)
-                re_opt  = re.search(RE_OPT,  line)
-                re_desc = re.search(RE_DESC, line)
-
-                if re_name and re_type and re_uri and re_opt and re_desc:
-                    entry = {}
-                    entry['name'] = re_name.groups()[0]
-                    entry['type'] = re_type.groups()[0]
-                    entry['uri']  = re_uri.groups()[0]
-                    entry['opt']  = re_opt.groups()[0]
-                    entry['desc'] = re_desc.groups()[0]
-
-                    self.entries.append(entry)
-
-                else:
-                    self.errors.append(line)
-
-    def check_entries(self, lib_names):
-
-        errors = 0
-
-        # Check for entries that are incorrectly formatted
-        for entry in self.entries:
-            nickname = entry['name']
-            uri = entry['uri']
-
-            if '\\' in uri:
-                print("Found '\\' character in entry '{nick}' - Path separators must be '/'".format(nick=nickname))
-                errors += 1
-
-            uri_last = '.'.join(uri.split('/')[-1].split('.')[:-1])
-
-            if not uri_last == nickname:
-                print("Nickname '{n}' does not match path '{p}'".format(n=nickname, p=uri))
-                errors += 1
-
-        lib_table_names = [entry['name'] for entry in self.entries]
-
-        # Check for libraries that are in the lib_table but should not be
-        for name in lib_table_names:
-            if not name in lib_names:
-                errors += 1
-                print("- Extra library '{l}' found in library table".format(l=name))
-
-            if lib_table_names.count(name) > 1:
-                errors += 1
-                print("- Library '{l}' is duplicated in table".format(l=name))
-
-        # Check for libraries that are not in the lib_table but should be
-        for name in lib_names:
-            if not name in lib_table_names:
-                errors += 1
-                print("- Library '{l}' missing from library table".format(l=name))
-
-        # Incorrect lines in the library table
-        for error in self.errors:
+        if '\\' in uri:
+            print("Found '\\' character in entry '{nick}' - Path separators must be '/'".format(nick=nickname))
             errors += 1
-            print("- Incorrect line found in library table:")
-            print("  - '{line}'".format(line=error))
 
-        return errors
+        uri_last = '.'.join(uri.split('/')[-1].split('.')[:-1])
+
+        if not uri_last == nickname:
+            print("Nickname '{n}' does not match path '{p}'".format(n=nickname, p=uri))
+            errors += 1
+
+    lib_table_names = [entry['name'] for entry in lib_table.entries]
+
+    # Check for libraries that are in the lib_table but should not be
+    for name in lib_table_names:
+        if not name in lib_names:
+            errors += 1
+            print("- Extra library '{l}' found in library table".format(l=name))
+
+        if lib_table_names.count(name) > 1:
+            errors += 1
+            print("- Library '{l}' is duplicated in table".format(l=name))
+
+    # Check for libraries that are not in the lib_table but should be
+    for name in lib_names:
+        if not name in lib_table_names:
+            errors += 1
+            print("- Library '{l}' missing from library table".format(l=name))
+
+    # Incorrect lines in the library table
+    for error in lib_table.errors:
+        errors += 1
+        print("- Incorrect line found in library table:")
+        print("  - '{line}'".format(line=error))
+
+    return errors
 
 
 lib_names = []
@@ -122,6 +84,6 @@ print("Found {n} libraries".format(n=len(lib_names)))
 
 table = LibTable(args.table)
 
-errors = table.check_entries(lib_names)
+errors = check_entries(table, lib_names)
 
 sys.exit(errors)

--- a/lib_table.py
+++ b/lib_table.py
@@ -1,0 +1,43 @@
+import re
+
+class LibTable:
+
+    def __init__(self, filename):
+
+        RE_NAME = r'\(name "?([^\)"]*)"?\)'
+        RE_TYPE = r'\(type "?([^\)"]*)"?\)'
+        RE_URI  = r'\(uri "?([^\)"]*)"?\)'
+        RE_OPT  = r'\(options "?([^\)"]*)"?\)'
+        RE_DESC = r'\(descr "?([^\)"]*)"?'
+
+        self.entries = []
+        self.errors = []
+
+        with open(filename, 'r') as lib_table_file:
+
+            for line in lib_table_file:
+
+                # Skip lines that do not define a library
+                if not '(lib ' in line:
+                    continue
+
+                re_name = re.search(RE_NAME, line)
+                re_type = re.search(RE_TYPE, line)
+                re_uri  = re.search(RE_URI,  line)
+                re_opt  = re.search(RE_OPT,  line)
+                re_desc = re.search(RE_DESC, line)
+
+                if re_name and re_type and re_uri and re_opt and re_desc:
+                    entry = {}
+                    entry['name'] = re_name.groups()[0]
+                    entry['type'] = re_type.groups()[0]
+                    entry['uri']  = re_uri.groups()[0]
+                    entry['opt']  = re_opt.groups()[0]
+                    entry['desc'] = re_desc.groups()[0]
+
+                    self.entries.append(entry)
+
+                else:
+                    self.errors.append(line)
+
+    


### PR DESCRIPTION
This makes re-using the LibTable class a bit easier and logical. It also remove schematic lib specific code from LibTable making it re-usable for footprint libraries.

Could be used to e.g check custom options in LibTables. I plan to use it together with the functionality of #297 to only check "approved" symbols in a symbol library by having a CSV "SYMBOLS" field in the library options. This makes something like this possible:

```python
# Check "enabled" symbols of all symbol libraries in a symbol library table for KLC compliance
import subprocess
import re
from importlib import import_module
LibTable = import_module("kicad-library-utils.lib_table").LibTable

lib_table = LibTable('sym_lib_table')

for library in lib_table.entries:
	re_symbols= re.search(r'SYMBOLS=([^ ]+)', library['opt'])
	checklib_args = []
	if re_symbols:
		symbols = re_symbols.groups()[0]
		checklib_args.extend(['-c', symbols])

	checklib_args.append(library['uri'].replace('${KICAD_SYMBOL_DIR}', '../symbols'))
	# TODO: make checklib work as python module
	subprocess.call(['./kicad-library-utils/schlib/checklib.py'] + checklib_args)
```

This could also be used to add an option to ignore certain rules for a symbol library, see #296.
