### PR TITLE
Fix S3.1 checker for multi-unit symbols.

### DIFF
--- a/schlib/rules/S3_1.py
+++ b/schlib/rules/S3_1.py
@@ -17,43 +17,49 @@ class Rule(KLCRule):
         single filled rectangle is present) or on pin positions.
         """
 
-        # If there is only a single filled rectangle, we assume that it is the
-        # main symbol outline.
-        drawing = self.component.draw
-        filled_rects = [rect for rect in drawing['rectangles']
-                        if rect['fill'] == 'f']
-        if len(filled_rects) == 1:
-            # We now find it's center
-            rect = filled_rects[0]
-            x = (int(rect['startx']) + int(rect['endx'])) // 2
-            y = (int(rect['starty']) + int(rect['endy'])) // 2
-        else:
-            pins = self.component.pins
+        # Check units separately if they have different drawing ("units_locked")
+        units_locked = self.component.definition['units_locked'] == 'L'
+        unit_count = int(self.component.definition['unit_count']) if units_locked else 1
 
-            # No pins? Ignore check.
-            # This can be improved to include graphical items too...
-            if len(pins) == 0:
-                return False
-            x_pos = [int(pin['posx']) for pin in pins]
-            y_pos = [int(pin['posy']) for pin in pins]
-            x_min = min(x_pos)
-            x_max = max(x_pos)
-            y_min = min(y_pos)
-            y_max = max(y_pos)
+        for unit in range(1, unit_count+1):
+            # If there is only a single filled rectangle, we assume that it is the
+            # main symbol outline.
+            drawing = self.component.draw
+            filled_rects = [rect for rect in drawing['rectangles']
+                            if ((not units_locked) or (int(rect['unit']) == unit)) and (rect['fill'] == 'f')]
+            if len(filled_rects) == 1:
+                # We now find it's center
+                rect = filled_rects[0]
+                x = (int(rect['startx']) + int(rect['endx'])) // 2
+                y = (int(rect['starty']) + int(rect['endy'])) // 2
+            else:
+                pins = [pin for pin in self.component.pins
+                        if (not units_locked) or (int(pin['unit']) == unit)]
 
-            # Center point average
-            x = (x_min + x_max) / 2
-            y = (y_min + y_max) / 2
+                # No pins? Ignore check.
+                # This can be improved to include graphical items too...
+                if len(pins) == 0:
+                    continue
+                x_pos = [int(pin['posx']) for pin in pins]
+                y_pos = [int(pin['posy']) for pin in pins]
+                x_min = min(x_pos)
+                x_max = max(x_pos)
+                y_min = min(y_pos)
+                y_max = max(y_pos)
 
-        # Right on the middle!
-        if x == 0 and y == 0:
-            return False
-        elif math.fabs(x) <= 50 and math.fabs(y) <= 50:
-            self.info("Symbol slightly off-center")
-            self.info("  Center calculated @ ({x}, {y})".format(x=x, y=y))
-        else:
-            self.warning("Symbol not centered on origin")
-            self.warningExtra("Center calculated @ ({x}, {y})".format(x=x, y=y))
+                # Center point average
+                x = (x_min + x_max) / 2
+                y = (y_min + y_max) / 2
+
+            # Right on the middle!
+            if x == 0 and y == 0:
+                continue
+            elif math.fabs(x) <= 50 and math.fabs(y) <= 50:
+                self.info("Symbol unit {unit} slightly off-center".format(unit=unit))
+                self.info("  Center calculated @ ({x}, {y})".format(x=x, y=y))
+            else:
+                self.warning("Symbol unit {unit} not centered on origin".format(unit=unit))
+                self.warningExtra("Center calculated @ ({x}, {y})".format(x=x, y=y))
 
         return False
 


### PR DESCRIPTION
This PR fix issue found during work at https://github.com/KiCad/kicad-library-utils/pull/293 

Current script checks symbol origin using pins and rectangles regardless of unit they belongs to. This leads to false rule violation for symbols which have multiple units with different drawing/pins.

New version of script process units individually if symbol has multiple units and "units_locked" flag.