### PR TITLE
Solves Issue #321: Check for space separated keywords

### DIFF
--- a/schlib/rules/S6_3.py
+++ b/schlib/rules/S6_3.py
@@ -76,10 +76,13 @@ class Rule(KLCRule):
 
         # Handle keyword seperator. Right now it filters based on a regular
         # expression based on certain symbols. Right now hyphen (-) is still allowed.
-        keywords = documentation.get('keywords', '')
-        forbidden_matches = re.findall('[,.:;?!<>]', keywords)
-        if forbidden_matches:
-            errors.append("Symbol keywords contain forbidden symbols: {}".format(forbidden_matches))
+        try:
+            keywords = documentation.get('keywords', '')
+            forbidden_matches = re.findall('[,.:;?!<>]', keywords)
+            if forbidden_matches:
+                errors.append("Symbol keywords contain forbidden symbols: {}".format(forbidden_matches))
+        except:
+            warnings.append("Symbol appears to not have any keywords.")
 
 
         if len(errors) > 0 or len(warnings) > 0:

--- a/schlib/rules/S6_3.py
+++ b/schlib/rules/S6_3.py
@@ -74,6 +74,14 @@ class Rule(KLCRule):
             if not link:
                 warnings.append("Datasheet entry '{ds}' does not look like a URL".format(ds=ds))
 
+        # Handle keyword seperator. Right now it filters based on a regular
+        # expression based on certain symbols. Right now hyphen (-) is still allowed.
+        keywords = documentation.get('keywords', '')
+        forbidden_matches = re.findall('[,.:;?!<>]', keywords)
+        if forbidden_matches:
+            errors.append("Symbol keywords contain forbidden symbols: {}".format(forbidden_matches))
+
+
         if len(errors) > 0 or len(warnings) > 0:
             msg = "{cmp} {name} has metadata errors:".format(
                 cmp="ALIAS" if alias else "Component",

--- a/schlib/rules/rule.py
+++ b/schlib/rules/rule.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import re
 
 common = os.path.abspath(os.path.join(sys.path[0], '..', 'common'))
 


### PR DESCRIPTION
A naive approach to handling space separated keywords fixing #321 

The thought was, that it would be more interesting to find keywords separated with a list of illegal symbols, such as: `,.:;?!<>`

Currently allowing especially hyphen (-) to get through, because it appears to be used already within keywords. A primary issue atm is, that some symbols such as within CPLD_Xilinx.lib contain no "K" field in its .dcm file. This triggered an error, that I handle with a try/except.

if the error is triggered it appends to the warnings, that symbols appear to not have any keywords. If illegal characters are found within the keywords, an error is appended saying it found the following illegal characters and prints them.

I would like to hear, what you think of the solution, and what specific sort of characters should be searched for within the keywords.