### PR TITLE
Add rouding to mmToMicrons() function

### DIFF
--- a/pcb/rules/rule.py
+++ b/pcb/rules/rule.py
@@ -23,7 +23,7 @@ def mmToMicrons(mm):
     elif mm > 0:
         mm += 0.0000005
 
-    return int(mm * 1E6)
+    return int(round(mm * 1E6))
 
 def getStartPoint(graph):
     if 'center' in graph:


### PR DESCRIPTION
For when using getStartPoint() on arcs combined with the mmToMicrons()
function the accuracy was not good leading to errors of the F5.3 check.
See https://github.com/KiCad/kicad-footprints/pull/2267

With rounding applied to the value before converting it to int that issue
is gone. This change won't break other rules since the function mmToMicrons()
is only used for rule F5.3.

Fixes #329