### PR TITLE
Handle module name as string

### DIFF
--- a/pcb/kicad_mod.py
+++ b/pcb/kicad_mod.py
@@ -62,7 +62,7 @@ class KicadMod(object):
         self.sexpr_data = sexpr_data
 
         # module name
-        self.name = self.sexpr_data[1]
+        self.name = str(self.sexpr_data[1])
 
         # module layer
         self.layer = self._getValue('layer', 'pth', 2)

--- a/pcb/rules/F5_2.py
+++ b/pcb/rules/F5_2.py
@@ -29,7 +29,7 @@ class Rule(KLCRule):
             self.error("Missing 'value' field")
             return True
 
-        if not val['value'] == mod.name:
+        if not str(val['value']) == mod.name:
             errors.append("Value text should match footprint name:")
             errors.append("Value text is '{v}', expected: '{n}'".format(
                 v = val['value'],

--- a/pcb/rules/F9_1.py
+++ b/pcb/rules/F9_1.py
@@ -49,7 +49,7 @@ class Rule(KLCRule):
             self.error("footprint name (in file) was '{0}', but expected (from filename) '{1}'.\n".format(module.name, os.path.splitext(os.path.basename(module.filename))[0]))
             err = True
 
-        if module.value['value'] != module.name:
+        if str(module.value['value']) != module.name:
             self.error("Value label '{lbl}' does not match filename '{fn}'".format(
                 lbl=module.value['value'],
                 fn = module.name))


### PR DESCRIPTION
If the module name contains only numeric characters, the variable should be converted to string to ensure the proper rules checking.