### PR TITLE
Fix F5.3 check

### DIFF
--- a/pcb/rules/F5_3.py
+++ b/pcb/rules/F5_3.py
@@ -177,12 +177,14 @@ class Rule(KLCRule):
 
         self.courtyard = self.fCourtyard + self.bCourtyard
 
-        GRID = int(KLC_CRTYD_GRID * 1E6)
 
         # Check for intersecting lines
         self.unconnected.extend(self.isClosed(self.fCourtyard))
         self.unconnected.extend(self.isClosed(self.bCourtyard))
 
+
+        # Check for elements that are not on the grid
+        GRID = mmToNanoMeter(KLC_CRTYD_GRID)
         for graph in self.courtyard:
             if graph['width'] != KLC_CRTYD_WIDTH:
                 self.bad_width.append(graph)
@@ -194,14 +196,16 @@ class Rule(KLCRule):
                 self.bad_grid.append(graph)
                 continue
 
-            x1 = mmToMicrons(start['x'])
-            y1 = mmToMicrons(start['y'])
-
-            x2 = mmToMicrons(end['x'])
-            y2 = mmToMicrons(end['y'])
-
+            # make a list of all x and y coordinates of this graphical elements
+            x1 = mmToNanoMeter(start['x'])
+            y1 = mmToNanoMeter(start['y'])
+            x2 = mmToNanoMeter(end['x'])
+            y2 = mmToNanoMeter(end['y'])
             check = [x1, y2, x2, y2]
 
+            # use a modulo division to check if those coordinates are on the grid
+            # if at least one of the coordinates is not on the grid, add this
+            # element to the bad_grid list
             grid_error = False
             for c in check:
                 if not (c % GRID) == 0:

--- a/pcb/rules/rule.py
+++ b/pcb/rules/rule.py
@@ -17,13 +17,8 @@ def mapToGrid(dimension, grid):
     return round(dimension / grid) * grid
 
 # Convert mm to microns
-def mmToMicrons(mm):
-    if mm < 0:
-        mm -= 0.0000005
-    elif mm > 0:
-        mm += 0.0000005
-
-    return int(round(mm * 1E6))
+def mmToNanoMeter(mm):
+    return round(mm * 1E6)
 
 def getStartPoint(graph):
     if 'center' in graph:


### PR DESCRIPTION
This fixes a regression from #334.

---

My testing when making #334 was not good enough. For some cases the weird `+0.00005` math breaks the rounding really bad.
I remove that block completely, the rounding is simpler and better.
At least my current testing shows that it now works again as intended.

@evanshultz can you please take a look. This breaks travis (false positives). So I would like to address that right away.

See https://github.com/KiCad/kicad-footprints/pull/2438#issuecomment-694928293